### PR TITLE
[FEAT] Carrot combo / streak multiplier system

### DIFF
--- a/Assets/_Project/Scripts/Core/AudioManager.cs
+++ b/Assets/_Project/Scripts/Core/AudioManager.cs
@@ -226,6 +226,7 @@ namespace ReverseRabbitRunner.Core
         /// <summary>
         /// Overlapping collect: duck all currently playing collect sources, then play new one.
         /// This creates a smooth layered sound when picking up many carrots quickly.
+        /// Pitch scales subtly with the current combo multiplier for audio escalation.
         /// </summary>
         private void PlayCollectOverlapping(AudioClip clip)
         {
@@ -242,9 +243,14 @@ namespace ReverseRabbitRunner.Core
             var src = collectSources[nextCollectSource];
             nextCollectSource = (nextCollectSource + 1) % collectSources.Length;
 
+            // Pitch up with combo multiplier (x1=1.0, x2=1.08, x3=1.16, x4=1.24, x5=1.32)
+            int mult = Core.ScoreManager.Instance != null
+                ? Core.ScoreManager.Instance.Multiplier : 1;
+            float comboPitch = 1f + (mult - 1) * 0.08f;
+
             src.clip = clip;
             src.volume = collectVolume * sfxVolume * masterVolume;
-            src.pitch = 1f + Random.Range(-0.08f, 0.08f);
+            src.pitch = comboPitch + Random.Range(-0.04f, 0.04f);
             src.Play();
         }
 

--- a/Assets/_Project/Scripts/Core/ScoreManager.cs
+++ b/Assets/_Project/Scripts/Core/ScoreManager.cs
@@ -4,23 +4,50 @@ namespace ReverseRabbitRunner.Core
 {
     /// <summary>
     /// Tracks score from carrot collection and manages high score persistence.
+    /// Also runs the combo / streak multiplier: collecting carrots in quick
+    /// succession scales each carrot's score value (x1 → x2 → x3 → x4 → x5).
+    /// A stumble or a too-long pause between collects breaks the streak.
     /// </summary>
     public class ScoreManager : MonoBehaviour
     {
         public static ScoreManager Instance { get; private set; }
 
+        [Header("Combo / Streak")]
+        [Tooltip("Seconds allowed between consecutive carrots before the combo resets.")]
+        [SerializeField] private float comboTimeWindow = 4f;
+
+        [Tooltip("Combo counts at which the multiplier ticks up. " +
+                 "Reaching index 0 = x2, index 1 = x3, etc. " +
+                 "Multiplier never exceeds tierThresholds.Length + 1.")]
+        [SerializeField] private int[] tierThresholds = new[] { 5, 15, 30, 60 };
+
         private int currentScore;
         private int highScore;
         private int carrotsCollected;
+
+        // Combo state
+        private int comboCount;
+        private int multiplier = 1;
+        private float comboExpireTime;
 
         private const string HighScoreKey = "HighScore";
 
         public int CurrentScore => currentScore;
         public int HighScore => highScore;
         public int CarrotsCollected => carrotsCollected;
+        public int ComboCount => comboCount;
+        public int Multiplier => multiplier;
+        public float ComboTimeRemaining =>
+            comboCount > 0 ? Mathf.Max(0f, comboExpireTime - Time.time) : 0f;
+        public float ComboTimeWindow => comboTimeWindow;
 
         public event System.Action<int> OnScoreChanged;
         public event System.Action<int> OnHighScoreBeaten;
+        /// <summary>
+        /// Fires whenever the combo count or multiplier changes (including reaching 0).
+        /// Args: (comboCount, multiplier, multiplierTierJustIncreased).
+        /// </summary>
+        public event System.Action<int, int, bool> OnComboChanged;
 
         private void Awake()
         {
@@ -36,11 +63,26 @@ namespace ReverseRabbitRunner.Core
             highScore = PlayerPrefs.GetInt(HighScoreKey, 0);
         }
 
-        public void AddScore(int points)
+        private void Update()
         {
-            currentScore += points;
+            // Combo expiry — uses scaled Time.time so it pauses with the game
+            if (comboCount > 0 && Time.time >= comboExpireTime)
+                BreakCombo();
+        }
+
+        public void AddScore(int basePoints)
+        {
+            // Bump combo first so the multiplier reflects THIS pickup
+            int previousMultiplier = multiplier;
+            comboCount++;
+            multiplier = ComputeMultiplier(comboCount);
+            comboExpireTime = Time.time + comboTimeWindow;
+
+            int gained = Mathf.Max(1, basePoints) * multiplier;
+            currentScore += gained;
             carrotsCollected++;
             OnScoreChanged?.Invoke(currentScore);
+            OnComboChanged?.Invoke(comboCount, multiplier, multiplier > previousMultiplier);
 
             if (currentScore > highScore)
             {
@@ -51,11 +93,34 @@ namespace ReverseRabbitRunner.Core
             }
         }
 
+        /// <summary>
+        /// Reset the combo streak (e.g. on stumble or expiry).
+        /// </summary>
+        public void BreakCombo()
+        {
+            if (comboCount == 0 && multiplier == 1) return;
+            comboCount = 0;
+            multiplier = 1;
+            OnComboChanged?.Invoke(0, 1, false);
+        }
+
         public void ResetScore()
         {
             currentScore = 0;
             carrotsCollected = 0;
+            BreakCombo();
             OnScoreChanged?.Invoke(currentScore);
+        }
+
+        private int ComputeMultiplier(int combo)
+        {
+            int tier = 1;
+            if (tierThresholds == null) return tier;
+            for (int i = 0; i < tierThresholds.Length; i++)
+            {
+                if (combo >= tierThresholds[i]) tier = i + 2;
+            }
+            return tier;
         }
     }
 }

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -371,6 +371,8 @@ namespace ReverseRabbitRunner.Player
 
             OnStumble?.Invoke(penalty);
             OnHitObstacle?.Invoke();
+            // Stumble breaks the carrot streak
+            Core.ScoreManager.Instance?.BreakCombo();
         }
 
         private void UpdateTargetPosition()

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -17,6 +17,11 @@ namespace ReverseRabbitRunner.UI
         private Core.DeathSequence cachedDeathSeq;
         private World.ChunkManager cachedChunkMgr;
 
+        // Combo display state
+        private GUIStyle comboStyle;
+        private GUIStyle comboBigStyle;
+        private float multiplierFlashTimer;  // tier-up celebration flash
+
         private GUIStyle scoreStyle;
         private GUIStyle warningStyle;
         private GUIStyle infoStyle;
@@ -43,6 +48,24 @@ namespace ReverseRabbitRunner.UI
 
             cachedDeathSeq = FindAnyObjectByType<Core.DeathSequence>();
             cachedChunkMgr = FindAnyObjectByType<World.ChunkManager>();
+
+            // Subscribe to combo events for the tier-up celebration animation.
+            // Subscription survives across sceneLoad because GameHUD itself is per-scene
+            // (re-Start runs on a fresh instance).
+            if (Core.ScoreManager.Instance != null)
+                Core.ScoreManager.Instance.OnComboChanged += OnComboChanged;
+        }
+
+        private void OnDestroy()
+        {
+            if (Core.ScoreManager.Instance != null)
+                Core.ScoreManager.Instance.OnComboChanged -= OnComboChanged;
+        }
+
+        private void OnComboChanged(int comboCount, int multiplier, bool tierIncreased)
+        {
+            if (tierIncreased)
+                multiplierFlashTimer = 1.2f;
         }
 
         private Core.DeathSequence GetDeathSeq()
@@ -56,6 +79,61 @@ namespace ReverseRabbitRunner.UI
         {
             if (cachedChunkMgr == null) cachedChunkMgr = FindAnyObjectByType<World.ChunkManager>();
             return cachedChunkMgr;
+        }
+
+        private static readonly Color[] ComboTierColors = new[]
+        {
+            new Color(1f, 1f, 1f),         // x1 (never shown — combo HUD hidden)
+            new Color(1f, 0.95f, 0.4f),    // x2 yellow
+            new Color(1f, 0.65f, 0.15f),   // x3 orange
+            new Color(1f, 0.3f, 0.2f),     // x4 red
+            new Color(1f, 0.3f, 0.95f),    // x5 magenta
+        };
+
+        private void DrawComboHUD(Core.ScoreManager score, float padding)
+        {
+            if (score == null || score.ComboCount <= 0) return;
+
+            // Small streak label below score
+            int multIdx = Mathf.Clamp(score.Multiplier - 1, 0, ComboTierColors.Length - 1);
+            Color tierColor = ComboTierColors[multIdx];
+            comboStyle.normal.textColor = tierColor;
+            string streakText = score.Multiplier > 1
+                ? $"🔥 x{score.Multiplier}  ({score.ComboCount} streak)"
+                : $"🔥 {score.ComboCount} streak";
+            // Below the existing Speed/Lane info lines
+            GUI.Label(new Rect(padding, padding + 100, 320, 30), streakText, comboStyle);
+
+            // Combo timer pill (thin bar showing how long until streak expires)
+            float remaining = score.ComboTimeRemaining;
+            float window = Mathf.Max(0.01f, score.ComboTimeWindow);
+            float fill = Mathf.Clamp01(remaining / window);
+            float barW = 220f;
+            float barH = 4f;
+            float barY = padding + 132f;
+            GUI.color = new Color(0f, 0f, 0f, 0.35f);
+            GUI.DrawTexture(new Rect(padding, barY, barW, barH), Texture2D.whiteTexture);
+            GUI.color = tierColor;
+            GUI.DrawTexture(new Rect(padding, barY, barW * fill, barH), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            // Tier-up celebration overlay
+            if (multiplierFlashTimer > 0f && score.Multiplier > 1)
+            {
+                float t = Mathf.Clamp01(multiplierFlashTimer / 1.2f);
+                // Fade out over the lifetime, big at start then settle
+                float alpha = t;
+                float scaleBoost = 0.5f + (1f - t) * 0.6f;     // 1.1 → 0.5
+                float fontScale = 1f + scaleBoost;
+
+                int oldFont = comboBigStyle.fontSize;
+                comboBigStyle.fontSize = Mathf.RoundToInt(64 * fontScale);
+                comboBigStyle.normal.textColor = new Color(tierColor.r, tierColor.g, tierColor.b, alpha);
+                string bigText = $"x{score.Multiplier}  COMBO!";
+                GUI.Label(new Rect(0, Screen.height * 0.18f, Screen.width, 120), bigText, comboBigStyle);
+                comboBigStyle.fontSize = oldFont;
+                comboBigStyle.normal.textColor = Color.white;
+            }
         }
 
         private void InitStyles()
@@ -90,6 +168,22 @@ namespace ReverseRabbitRunner.UI
                 alignment = TextAnchor.MiddleCenter
             };
             gameOverStyle.normal.textColor = Color.red;
+
+            comboStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 22,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.UpperLeft
+            };
+            comboStyle.normal.textColor = new Color(1f, 0.85f, 0.2f);
+
+            comboBigStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 64,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter
+            };
+            comboBigStyle.normal.textColor = Color.white;
 
             stylesInitialized = true;
         }
@@ -133,6 +227,8 @@ namespace ReverseRabbitRunner.UI
             wasStumbling = currentlyStumbling;
             if (stumbleFlashTimer > 0f)
                 stumbleFlashTimer -= Time.unscaledDeltaTime;
+            if (multiplierFlashTimer > 0f)
+                multiplierFlashTimer -= Time.unscaledDeltaTime;
         }
 
         private void OnGUI()
@@ -154,6 +250,8 @@ namespace ReverseRabbitRunner.UI
             string scoreText = $"🥕 {(score != null ? score.CurrentScore : 0)}";
             GUI.Label(new Rect(padding, padding, 300, 50), scoreText, scoreStyle);
 
+            // Combo / streak indicator (under-score, only when active)
+            DrawComboHUD(score, padding);
             // Speed (below score)
             if (rabbit != null)
             {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ It's like having a tireless junior dev who never needs coffee but occasionally p
 - 👨‍🌾 Angry farmer with hat, pitchfork, scowling face, and AI pursuit
 - 🧠 Farmer obstacle avoidance AI — scans ahead, switches lanes, stumbles on hits, disappears when far behind, reappears after delay
 - 🥕 Carrot collecting with score tracking and bobbing animation
+- 🔥 **Combo / streak multiplier** — collect carrots in quick succession to build a streak (x2 → x5). Stumble or stop collecting and the streak resets. Pitch-rising audio + on-screen tier-up celebration.
 - 🛤️ 5-lane switching (A/D or arrow keys)
 - 🦘 Jump mechanic (Space) — clear obstacles and collect mid-air carrots
 - 🌍 Chunk-based infinite world with 3 themed biomes (Concrete, Snow+Mud, Grass)


### PR DESCRIPTION
Adds combo streak system: x2/x3/x4/x5 multipliers with HUD celebration, audio pitch escalation, and stumble-resets-streak. See commit message for details.