### PR TITLE
Screen shake + near-miss dodge bonuses

### DIFF
--- a/Assets/_Project/Scripts/Player/CameraFollow.cs
+++ b/Assets/_Project/Scripts/Player/CameraFollow.cs
@@ -26,7 +26,37 @@ namespace ReverseRabbitRunner.Player
         private bool isInFlightMode;
         private Vector3 normalLookOffset = new Vector3(0, 0.5f, 5f);
 
+        // Screen shake state
+        private float shakeIntensity;
+        private float shakeRemaining;
+        private float shakeDuration;
+        private static CameraFollow instance;
+        public static CameraFollow Instance => instance;
+
         public void SetFlightMode(bool flight) => isInFlightMode = flight;
+
+        /// <summary>
+        /// Trigger a screen shake. New shakes override weaker ones in progress.
+        /// Intensity is in world units (0.05 = subtle, 0.4 = big hit).
+        /// </summary>
+        public void Shake(float intensity, float duration)
+        {
+            // Don't downgrade an in-progress stronger shake
+            if (intensity * duration < shakeIntensity * shakeRemaining) return;
+            shakeIntensity = intensity;
+            shakeDuration = duration;
+            shakeRemaining = duration;
+        }
+
+        private void Awake()
+        {
+            instance = this;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this) instance = null;
+        }
 
         private void Start()
         {
@@ -53,6 +83,19 @@ namespace ReverseRabbitRunner.Player
             Vector3 lookOffset = isInFlightMode ? flightLookOffset : normalLookOffset;
             Vector3 lookTarget = target.position + lookOffset;
             transform.LookAt(lookTarget);
+
+            // Apply screen shake AFTER position + look so it's a pure visual perturbation
+            if (shakeRemaining > 0f)
+            {
+                shakeRemaining -= Time.unscaledDeltaTime;
+                float t = Mathf.Clamp01(shakeRemaining / Mathf.Max(0.0001f, shakeDuration));
+                float falloff = t * t;
+                Vector3 jitter = new Vector3(
+                    (Random.value - 0.5f) * 2f,
+                    (Random.value - 0.5f) * 2f,
+                    0f) * shakeIntensity * falloff;
+                transform.position += transform.right * jitter.x + transform.up * jitter.y;
+            }
 
             // Speed-based FOV increase
             if (cam != null)

--- a/Assets/_Project/Scripts/Player/NearMissDetector.cs
+++ b/Assets/_Project/Scripts/Player/NearMissDetector.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Player
+{
+    /// <summary>
+    /// Sits on a wider trigger collider parented to the rabbit. Tracks every
+    /// "Obstacle" that enters this zone; when an obstacle leaves the zone
+    /// without having caused a stumble (and is still alive — i.e. wasn't
+    /// destroyed by a successful jump), it counts as a near-miss.
+    ///
+    /// Fires <see cref="OnNearMiss"/> with the obstacle that was dodged.
+    /// Listeners (CameraFollow shake, ScoreManager bonus, HUD label) wire up
+    /// in RabbitController.
+    /// </summary>
+    public class NearMissDetector : MonoBehaviour
+    {
+        public RabbitController rabbit;
+        /// <summary>Stumble within this many seconds of obstacle exit invalidates the near-miss.</summary>
+        public float stumbleGraceSeconds = 0.4f;
+        public System.Action<GameObject> OnNearMiss;
+
+        private readonly Dictionary<int, float> entered = new();
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!other.CompareTag("Obstacle")) return;
+            entered[other.GetInstanceID()] = Time.time;
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!other.CompareTag("Obstacle")) return;
+            int id = other.GetInstanceID();
+            if (!entered.Remove(id)) return;
+
+            if (rabbit == null || !rabbit.IsAlive) return;
+            // If we just stumbled, this obstacle WAS the hit — not a near-miss
+            if (Time.time - rabbit.LastStumbleTime < stumbleGraceSeconds) return;
+
+            OnNearMiss?.Invoke(other.gameObject);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -71,10 +71,13 @@ namespace ReverseRabbitRunner.Player
         public bool IsStumbling => isStumbling;
         public bool IsFlying => isFlying;
         public bool InDangerWindow => (Time.time - lastStumbleTime) < stumbleDangerWindow;
+        public float LastStumbleTime => lastStumbleTime;
 
         public event System.Action OnHitObstacle;
         public event System.Action<float> OnStumble;
         public event System.Action<GameObject> OnCollectCarrot;
+        /// <summary>Fires when the rabbit dodges or jump-clears an obstacle without stumbling.</summary>
+        public event System.Action<GameObject> OnNearMiss;
 
         private void Awake()
         {
@@ -86,6 +89,38 @@ namespace ReverseRabbitRunner.Player
             // Find "Body" child for tilt animation
             var body = transform.Find("Body");
             if (body != null) bodyTransform = body;
+
+            BuildNearMissZone();
+        }
+
+        private void BuildNearMissZone()
+        {
+            // Wider trigger zone surrounding the rabbit — detects obstacles that
+            // pass close by without actually colliding. A NearMissDetector child
+            // forwards "obstacle exited zone alive" events as OnNearMiss.
+            var zone = new GameObject("NearMissZone");
+            zone.transform.SetParent(transform, false);
+            zone.transform.localPosition = Vector3.zero;
+            zone.layer = gameObject.layer;
+
+            var box = zone.AddComponent<BoxCollider>();
+            box.isTrigger = true;
+            // Wider than rabbit's collider but narrower than two lanes — so an obstacle
+            // in an *adjacent* lane only registers a near-miss if the player swerved
+            // close to the boundary, not if they were comfortably one full lane over.
+            box.size = new Vector3(4.4f, 2.6f, 1.8f);
+            box.center = new Vector3(0f, 0.6f, 0f);
+
+            // A trigger needs a Rigidbody on one of the participants to fire OnTrigger
+            // events with CharacterController-only objects. Mark it kinematic so it
+            // doesn't influence physics.
+            var rb = zone.AddComponent<Rigidbody>();
+            rb.isKinematic = true;
+            rb.useGravity = false;
+
+            var detector = zone.AddComponent<NearMissDetector>();
+            detector.rabbit = this;
+            detector.OnNearMiss += go => OnNearMiss?.Invoke(go);
         }
 
         private void OnEnable()
@@ -405,6 +440,7 @@ namespace ReverseRabbitRunner.Player
 
                     if (rabbitFeetY >= obstacleTopY - 0.2f)
                     {
+                        OnNearMiss?.Invoke(other.gameObject);
                         if (isSmall) Destroy(other.gameObject);
                         return;
                     }

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -21,6 +21,7 @@ namespace ReverseRabbitRunner.UI
         private GUIStyle comboStyle;
         private GUIStyle comboBigStyle;
         private float multiplierFlashTimer;  // tier-up celebration flash
+        private float nearMissFlashTimer;    // "NICE!" pop on dodge
 
         private GUIStyle scoreStyle;
         private GUIStyle warningStyle;
@@ -54,18 +55,50 @@ namespace ReverseRabbitRunner.UI
             // (re-Start runs on a fresh instance).
             if (Core.ScoreManager.Instance != null)
                 Core.ScoreManager.Instance.OnComboChanged += OnComboChanged;
+
+            // Wire rabbit feedback events to camera shake + HUD pop
+            if (rabbit != null)
+            {
+                rabbit.OnStumble += OnRabbitStumble;
+                rabbit.OnNearMiss += OnRabbitNearMiss;
+            }
         }
 
         private void OnDestroy()
         {
             if (Core.ScoreManager.Instance != null)
                 Core.ScoreManager.Instance.OnComboChanged -= OnComboChanged;
+            if (rabbit != null)
+            {
+                rabbit.OnStumble -= OnRabbitStumble;
+                rabbit.OnNearMiss -= OnRabbitNearMiss;
+            }
         }
 
         private void OnComboChanged(int comboCount, int multiplier, bool tierIncreased)
         {
             if (tierIncreased)
+            {
                 multiplierFlashTimer = 1.2f;
+                // Subtle "you levelled up" camera punch
+                Player.CameraFollow.Instance?.Shake(0.15f, 0.22f);
+            }
+        }
+
+        private void OnRabbitStumble(float penalty)
+        {
+            // Bigger shake for tall/heavy stumbles
+            float intensity = penalty >= 3f ? 0.45f : 0.25f;
+            Player.CameraFollow.Instance?.Shake(intensity, 0.30f);
+        }
+
+        private void OnRabbitNearMiss(GameObject obstacle)
+        {
+            Player.CameraFollow.Instance?.Shake(0.08f, 0.15f);
+            nearMissFlashTimer = 0.7f;
+            // Reward the dodge — half a carrot's worth, and it counts as a streak hit
+            // so dodging masterfully also builds your combo.
+            Core.ScoreManager.Instance?.AddScore(1);
         }
 
         private Core.DeathSequence GetDeathSeq()
@@ -134,6 +167,22 @@ namespace ReverseRabbitRunner.UI
                 comboBigStyle.fontSize = oldFont;
                 comboBigStyle.normal.textColor = Color.white;
             }
+        }
+
+        private void DrawNearMissPop()
+        {
+            if (nearMissFlashTimer <= 0f) return;
+            float t = Mathf.Clamp01(nearMissFlashTimer / 0.7f);
+            float alpha = t;
+            float yOffset = (1f - t) * -40f;  // floats upward as it fades
+
+            int oldFont = comboBigStyle.fontSize;
+            comboBigStyle.fontSize = 36;
+            comboBigStyle.normal.textColor = new Color(0.6f, 1f, 0.4f, alpha);
+            GUI.Label(new Rect(0, Screen.height * 0.55f + yOffset, Screen.width, 50),
+                "NICE DODGE!  +1", comboBigStyle);
+            comboBigStyle.fontSize = oldFont;
+            comboBigStyle.normal.textColor = Color.white;
         }
 
         private void InitStyles()
@@ -229,6 +278,8 @@ namespace ReverseRabbitRunner.UI
                 stumbleFlashTimer -= Time.unscaledDeltaTime;
             if (multiplierFlashTimer > 0f)
                 multiplierFlashTimer -= Time.unscaledDeltaTime;
+            if (nearMissFlashTimer > 0f)
+                nearMissFlashTimer -= Time.unscaledDeltaTime;
         }
 
         private void OnGUI()
@@ -252,6 +303,7 @@ namespace ReverseRabbitRunner.UI
 
             // Combo / streak indicator (under-score, only when active)
             DrawComboHUD(score, padding);
+            DrawNearMissPop();
             // Speed (below score)
             if (rabbit != null)
             {

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ It's like having a tireless junior dev who never needs coffee but occasionally p
 - 🧠 Farmer obstacle avoidance AI — scans ahead, switches lanes, stumbles on hits, disappears when far behind, reappears after delay
 - 🥕 Carrot collecting with score tracking and bobbing animation
 - 🔥 **Combo / streak multiplier** — collect carrots in quick succession to build a streak (x2 → x5). Stumble or stop collecting and the streak resets. Pitch-rising audio + on-screen tier-up celebration.
+- 💥 **Screen shake & near-miss bonus** — the camera punches on stumbles and tier-ups, and dodging an obstacle by a hair triggers a "NICE DODGE!" pop with a small score reward (which also feeds your streak).
 - 🛤️ 5-lane switching (A/D or arrow keys)
 - 🦘 Jump mechanic (Space) — clear obstacles and collect mid-air carrots
 - 🌍 Chunk-based infinite world with 3 themed biomes (Concrete, Snow+Mud, Grass)


### PR DESCRIPTION
Adds juicy reactive feedback on top of the combo system.

## What's new
- **Camera shake API** (CameraFollow.Shake) with t² falloff. Stronger pending shakes are not clobbered by weaker ones.
- **Stumble shake** — every wipeout punches the camera (bigger for tall obstacles).
- **Combo tier-up shake** — a subtle camera nudge on x2 → x3 → x4 → x5.
- **Near-miss detector** — a wide trigger zone parented to the rabbit. Obstacles that enter and leave the zone without causing a stumble fire OnNearMiss → small shake + 'NICE DODGE!' HUD pop + 1-point bonus that also extends the combo streak.
- **Jump-clear near-miss** — successful jumps over small obstacles also count as a dodge (those obstacles get destroyed before exiting the zone).

## Files
- New: `Player/NearMissDetector.cs`
- `Player/CameraFollow.cs` — Shake API + static instance
- `Player/RabbitController.cs` — LastStumbleTime accessor, OnNearMiss event, NearMissZone spawn, jump-clear hook
- `UI/GameHUD.cs` — event subscriptions + 'NICE DODGE!' overlay
- `README.md` — feature bullet

## Notes
- Detector zone is 4.4u wide — covers the rabbit's lane plus a small slice of adjacent lanes. Obstacles a full lane away don't register.
- Real hits are excluded by a 0.4s stumble grace window (lastStumbleTime is updated *before* the disabled-collider OnTriggerExit fires).
- Near-miss bonus runs through `ScoreManager.AddScore` so it both rewards and feeds the combo streak.