### PR TITLE
Magnet-Carrot power-up (#4)

### DIFF
--- a/Assets/_Project/Scripts/Core/CheatConsole.cs
+++ b/Assets/_Project/Scripts/Core/CheatConsole.cs
@@ -76,6 +76,7 @@ namespace ReverseRabbitRunner.Core
                 ["die"]     = _ => TriggerDeath(),
                 ["wing"]    = _ => TriggerWingCarrot(),
                 ["fly"]     = _ => TriggerWingCarrot(),
+                ["magnet"]  = _ => TriggerMagnetCarrot(),
                 ["test"]    = RunTest,
                 ["overlay"] = _ => DebugOverlay.Toggle(),
             };
@@ -272,6 +273,7 @@ namespace ReverseRabbitRunner.Core
             Log("fstumble     Force farmer stumble", Color.white);
             Log("die          Trigger instant death", Color.white);
             Log("wing/fly     Activate Wing-Carrot flight", Color.white);
+            Log("magnet       Activate Magnet-Carrot (auto-collect)", Color.white);
             Log("test <name>  Run test (flight/farmer/stumble/distance/all)", Color.white);
             Log("overlay      Toggle debug overlay (or F11)", Color.white);
             Log("clear        Clear console", Color.white);
@@ -404,6 +406,25 @@ namespace ReverseRabbitRunner.Core
             var fc = rabbit.gameObject.AddComponent<PowerUps.FlightController>();
             fc.Initialize(rabbit, 6f, 8f);
             Log("Wing-Carrot! FLIGHT MODE!", Color.cyan);
+        }
+
+        private void TriggerMagnetCarrot()
+        {
+            var rabbit = FindFirstObjectByType<Player.RabbitController>();
+            if (rabbit == null) { Log("No rabbit found!", Color.red); return; }
+
+            var existing = rabbit.GetComponent<PowerUps.MagnetEffect>();
+            if (existing != null)
+            {
+                existing.Refresh(6f, 12f);
+                Log("Magnet-Carrot refreshed!", Color.yellow);
+            }
+            else
+            {
+                var me = rabbit.gameObject.AddComponent<PowerUps.MagnetEffect>();
+                me.Initialize(rabbit, 6f, 12f);
+                Log("Magnet-Carrot! Carrots HOMING!", Color.yellow);
+            }
         }
 
         private void FarmerStatus()

--- a/Assets/_Project/Scripts/Core/DebugOverlay.cs
+++ b/Assets/_Project/Scripts/Core/DebugOverlay.cs
@@ -140,6 +140,12 @@ namespace ReverseRabbitRunner.Core
                 DrawLine(ref cy, x, w, lineH, style,
                     $"<color=#ff88ff>🍼 {babyCount} babies active</color>");
 
+            // Magnet
+            var magnet = PowerUps.MagnetEffect.Active;
+            if (magnet != null)
+                DrawLine(ref cy, x, w, lineH, style,
+                    $"<color=#ffd84a>✨ MAGNET {magnet.Remaining:0.0}s</color>");
+
             // World stats
             var chunk = FindAnyObjectByType<World.ChunkManager>();
             if (chunk != null)

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -79,6 +79,17 @@ namespace ReverseRabbitRunner.Player
         /// <summary>Fires when the rabbit dodges or jump-clears an obstacle without stumbling.</summary>
         public event System.Action<GameObject> OnNearMiss;
 
+        /// <summary>
+        /// Single-source-of-truth pickup hook. Used by both direct trigger collection
+        /// and the Magnet-Carrot auto-collect so events / score / combo all flow
+        /// through the same code path.
+        /// </summary>
+        public void NotifyCarrotCollected(GameObject carrot)
+        {
+            OnCollectCarrot?.Invoke(carrot);
+            Core.ScoreManager.Instance?.AddScore(1);
+        }
+
         private void Awake()
         {
             controller = GetComponent<CharacterController>();
@@ -422,8 +433,7 @@ namespace ReverseRabbitRunner.Player
 
             if (other.CompareTag("Carrot"))
             {
-                OnCollectCarrot?.Invoke(other.gameObject);
-                Core.ScoreManager.Instance?.AddScore(1);
+                NotifyCarrotCollected(other.gameObject);
                 Destroy(other.gameObject);
             }
             else if (other.CompareTag("Obstacle"))

--- a/Assets/_Project/Scripts/PowerUps/MagnetCarrot.cs
+++ b/Assets/_Project/Scripts/PowerUps/MagnetCarrot.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.PowerUps
+{
+    /// <summary>
+    /// Magnet-Carrot: For a few seconds, normal carrots within a radius around the
+    /// rabbit accelerate toward it and auto-collect on close approach. Boosts
+    /// combo-streak feasibility — chained collects are easy, x5 multiplier is reachable.
+    /// </summary>
+    public class MagnetCarrot : PowerUpBase
+    {
+        [Header("Magnet Settings")]
+        [SerializeField] private float magnetDuration = 6f;
+        [SerializeField] private float magnetRadius = 12f;
+
+        protected override void Activate(Player.RabbitController rabbit)
+        {
+            isActive = true;
+
+            var existing = rabbit.GetComponent<MagnetEffect>();
+            if (existing != null)
+            {
+                // Stack/refresh: extend duration instead of adding a second component
+                existing.Refresh(magnetDuration, magnetRadius);
+                Debug.Log("[MagnetCarrot] Refreshed existing magnet.");
+            }
+            else
+            {
+                var me = rabbit.gameObject.AddComponent<MagnetEffect>();
+                me.Initialize(rabbit, magnetDuration, magnetRadius);
+                Debug.Log("[MagnetCarrot] Activated! Carrots will home in.");
+            }
+
+            Destroy(gameObject);
+        }
+
+        protected override void Deactivate(Player.RabbitController rabbit)
+        {
+            isActive = false;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs
+++ b/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.PowerUps
+{
+    /// <summary>
+    /// Runtime carrier for the Magnet-Carrot power-up. Lives on the rabbit while
+    /// active, scans for nearby carrots each frame, accelerates them toward the
+    /// rabbit and auto-collects on close approach (counts toward the combo streak
+    /// just like a manual pickup).
+    ///
+    /// Self-destroys when the timer expires.
+    /// </summary>
+    public class MagnetEffect : MonoBehaviour
+    {
+        private Player.RabbitController rabbit;
+        private float remaining;
+        private float originalDuration;
+        private float radius;
+        private float pullSpeedMax = 28f;        // peak homing speed (units/sec)
+        private float collectDistance = 1.4f;    // auto-pick threshold
+
+        private static readonly Collider[] hits = new Collider[32];
+
+        // Per-carrot momentum so the home-in feels physical, not jumpy
+        private readonly Dictionary<int, float> carrotSpeeds = new();
+
+        // Static so HUD / DebugOverlay can show remaining time
+        public static MagnetEffect Active { get; private set; }
+        public float Remaining => remaining;
+        public float DurationFraction => originalDuration <= 0f ? 0f : Mathf.Clamp01(remaining / originalDuration);
+
+        public void Initialize(Player.RabbitController r, float duration, float radiusUnits)
+        {
+            rabbit = r;
+            remaining = duration;
+            originalDuration = duration;
+            radius = radiusUnits;
+            Active = this;
+        }
+
+        public void Refresh(float duration, float radiusUnits)
+        {
+            // Extend rather than stack. Take the max so refresh never shortens the buff.
+            remaining = Mathf.Max(remaining, duration);
+            originalDuration = Mathf.Max(originalDuration, duration);
+            radius = Mathf.Max(radius, radiusUnits);
+        }
+
+        private void Update()
+        {
+            if (rabbit == null || !rabbit.IsAlive)
+            {
+                EndEffect();
+                return;
+            }
+
+            remaining -= Time.deltaTime;
+            if (remaining <= 0f)
+            {
+                EndEffect();
+                return;
+            }
+
+            PullCarrots();
+        }
+
+        private void PullCarrots()
+        {
+            Vector3 rabbitPos = rabbit.transform.position;
+
+            int count = Physics.OverlapSphereNonAlloc(rabbitPos, radius, hits);
+            for (int i = 0; i < count; i++)
+            {
+                var col = hits[i];
+                if (col == null) continue;
+                // Only pull plain carrots — power-up carrots (BirthCarrot/WingCarrot/MagnetCarrot)
+                // shouldn't be auto-grabbed; the player should choose to pick them.
+                if (!col.CompareTag("Carrot")) continue;
+
+                int id = col.GetInstanceID();
+                Vector3 toRabbit = rabbitPos - col.transform.position;
+                float dist = toRabbit.magnitude;
+
+                if (dist <= collectDistance)
+                {
+                    // Auto-collect: route through ScoreManager so it counts for the combo
+                    rabbit.NotifyCarrotCollected(col.gameObject);
+                    carrotSpeeds.Remove(id);
+                    Destroy(col.gameObject);
+                    continue;
+                }
+
+                // Ramp homing speed up as the carrot gets closer (feels juicy)
+                float t = 1f - Mathf.Clamp01(dist / radius);
+                float targetSpeed = Mathf.Lerp(6f, pullSpeedMax, t * t);
+
+                if (!carrotSpeeds.TryGetValue(id, out float speed)) speed = 0f;
+                speed = Mathf.MoveTowards(speed, targetSpeed, 30f * Time.deltaTime);
+                carrotSpeeds[id] = speed;
+
+                Vector3 dir = toRabbit / Mathf.Max(dist, 0.0001f);
+                col.transform.position += dir * speed * Time.deltaTime;
+            }
+
+            // Periodic light cleanup of dead IDs
+            if (carrotSpeeds.Count > 64)
+                carrotSpeeds.Clear();
+        }
+
+        private void EndEffect()
+        {
+            if (Active == this) Active = null;
+            Destroy(this);
+        }
+
+        private void OnDestroy()
+        {
+            if (Active == this) Active = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -185,6 +185,41 @@ namespace ReverseRabbitRunner.UI
             comboBigStyle.normal.textColor = Color.white;
         }
 
+        private void DrawMagnetHUD(float padding)
+        {
+            var magnet = PowerUps.MagnetEffect.Active;
+            if (magnet == null) return;
+
+            float frac = magnet.DurationFraction;
+            float barW = 220f;
+            float barH = 14f;
+            float x = Screen.width - barW - padding;
+            float y = padding + 80f;     // sits below the score panel
+
+            // Background
+            GUI.color = new Color(0f, 0f, 0f, 0.55f);
+            GUI.DrawTexture(new Rect(x - 4, y - 18, barW + 8, barH + 26), Texture2D.whiteTexture);
+
+            // Label
+            var label = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14,
+                alignment = TextAnchor.MiddleLeft,
+                fontStyle = FontStyle.Bold
+            };
+            label.normal.textColor = new Color(1f, 0.9f, 0.3f);
+            GUI.color = Color.white;
+            GUI.Label(new Rect(x, y - 18, barW, 18), $"\u2728 MAGNET  {magnet.Remaining:0.0}s", label);
+
+            // Bar background
+            GUI.color = new Color(0.2f, 0.18f, 0.05f, 0.9f);
+            GUI.DrawTexture(new Rect(x, y, barW, barH), Texture2D.whiteTexture);
+            // Bar fill (gold)
+            GUI.color = new Color(1f, 0.85f, 0.15f, 0.95f);
+            GUI.DrawTexture(new Rect(x, y, barW * frac, barH), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+        }
+
         private void InitStyles()
         {
             scoreStyle = new GUIStyle(GUI.skin.label)
@@ -304,6 +339,7 @@ namespace ReverseRabbitRunner.UI
             // Combo / streak indicator (under-score, only when active)
             DrawComboHUD(score, padding);
             DrawNearMissPop();
+            DrawMagnetHUD(padding);
             // Speed (below score)
             if (rabbit != null)
             {

--- a/Assets/_Project/Scripts/World/ChunkManager.cs
+++ b/Assets/_Project/Scripts/World/ChunkManager.cs
@@ -43,6 +43,7 @@ namespace ReverseRabbitRunner.World
         [SerializeField] private int powerUpStartChunk = 6;
         [SerializeField] private float birthCarrotChance = 0.25f;
         [SerializeField] private float wingCarrotChance = 0.15f;
+        [SerializeField] private float magnetCarrotChance = 0.18f;
 
         // Public stats for HUD
         public float TotalDistance { get; private set; }
@@ -628,22 +629,31 @@ namespace ReverseRabbitRunner.World
         private Material powerUpLeavesMat;
         private Material powerUpWingMat;
         private Material powerUpWingLeavesMat;
+        private Material powerUpMagnetMat;
+        private Material powerUpMagnetLeavesMat;
 
         private void SpawnPowerUpsInChunk(Transform parent, float chunkStartZ, int chunkIndex)
         {
             if (chunkIndex < powerUpStartChunk) return;
 
-            // Don't spawn Birth-Carrot if babies are active; don't spawn Wing-Carrot if flying
+            // Don't spawn Birth-Carrot if babies are active; don't spawn Wing-Carrot if flying;
+            // don't spawn Magnet-Carrot if one is already active on the rabbit.
             bool babiesActive = PowerUps.BabyRabbit.ActiveBabies.Count > 0;
             var rabbit = GameObject.FindGameObjectWithTag("Player");
             bool isFlying = rabbit != null && rabbit.GetComponent<Player.RabbitController>()?.IsFlying == true;
+            bool magnetActive = PowerUps.MagnetEffect.Active != null;
 
             // Roll for which power-up to spawn (mutually exclusive per chunk)
             float roll = Random.value;
-            bool spawnBirth = !babiesActive && roll < birthCarrotChance;
-            bool spawnWing = !isFlying && !spawnBirth && roll < birthCarrotChance + wingCarrotChance;
+            float birthCutoff = babiesActive ? 0f : birthCarrotChance;
+            float wingCutoff = birthCutoff + (isFlying ? 0f : wingCarrotChance);
+            float magnetCutoff = wingCutoff + (magnetActive ? 0f : magnetCarrotChance);
 
-            if (!spawnBirth && !spawnWing) return;
+            bool spawnBirth = roll < birthCutoff;
+            bool spawnWing = !spawnBirth && roll < wingCutoff;
+            bool spawnMagnet = !spawnBirth && !spawnWing && roll < magnetCutoff;
+
+            if (!spawnBirth && !spawnWing && !spawnMagnet) return;
 
             int lane = Random.Range(0, maxLanes);
             float xPos = (lane - maxLanes / 2) * laneWidth;
@@ -668,6 +678,16 @@ namespace ReverseRabbitRunner.World
                 }
                 SpawnPowerUpCarrot(parent, xPos, zPos, "WingCarrot",
                     powerUpWingMat, powerUpWingLeavesMat, typeof(PowerUps.WingCarrot));
+            }
+            else // spawnMagnet
+            {
+                if (powerUpMagnetMat == null)
+                {
+                    powerUpMagnetMat = MakeMat(new Color(1f, 0.85f, 0.15f));      // bright gold body
+                    powerUpMagnetLeavesMat = MakeMat(new Color(0.95f, 0.7f, 0.1f)); // amber leaves
+                }
+                SpawnPowerUpCarrot(parent, xPos, zPos, "MagnetCarrot",
+                    powerUpMagnetMat, powerUpMagnetLeavesMat, typeof(PowerUps.MagnetCarrot));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You're a rabbit. You run backwards through an endless carrot farm. You have two 
 |--------|--------|
 | 🍼 **Birth-Carrot** | Instantly birth baby rabbits that spread across all lanes, hoovering up carrots. They'll slowly get picked off by obstacles and the farmer though. Circle of life. |
 | 🪽 **Wing-Carrot** | Flip around and FLY! Glide forward (the right way for once) and grab airborne carrot lines. Brief taste of freedom. |
+| ✨ **Magnet-Carrot** | A bright gold carrot that turns the rabbit into a hoover for 6 seconds — nearby carrots tear themselves out of the ground and home in. Combo-streak nirvana. |
 | 🤢 **Dirty-Carrot** | Smears your mirrors with mud. Even less visibility than before. Thanks, nature. |
 | ❓ **More to come...** | We have ideas. Terrible, wonderful ideas. |
 
@@ -89,6 +90,7 @@ It's like having a tireless junior dev who never needs coffee but occasionally p
 - 🚜 Tractor flatbed platforms — jump on top for a carrot jackpot (~100+ bonus carrots!)
 - 🍼 Birth-Carrot power-up — spawns 125 chaotic rainbow baby rabbits that swarm across lanes hoovering up carrots
 - 🪽 Wing-Carrot power-up — backflip into the sky and FLY! Glide forward collecting airborne carrot streams, then backflip home
+- ✨ Magnet-Carrot power-up — gold pickup that auto-collects carrots within a wide radius for ~6s; pairs beautifully with the streak system
 - 🤢 Dirty-Carrot power-up — smears mirrors with mud for reduced visibility (difficulty modifier)
 - 💀 Dramatic 7-stage cinematic death sequence (orbit camera, blood/carrot particles, fork stab)
 - 🔊 Full SFX system — 14 AI-generated sound effects (jump, land, collect, stumble, death, game over, danger warning, etc.)
@@ -167,6 +169,7 @@ Open with `Shift+F12` during gameplay:
 | `fdist [n]` | Show or set farmer distance |
 | `die` | Trigger death sequence |
 | `wing` / `fly` | Activate Wing-Carrot flight |
+| `magnet` | Activate Magnet-Carrot (auto-collect carrots) |
 | `test <name>` | Run automated test (`flight`, `farmer`, `stumble`, `distance`, `all`) |
 | `overlay` | Toggle debug overlay (same as F11) |
 | `clear` | Clear console |


### PR DESCRIPTION
Ships the 4th power-up promised by the brief, and a great partner for the combo system.

## What it does
A bright gold carrot. Pick it up and for ~6 seconds nearby carrots tear themselves out of the field and home in on the rabbit, auto-collecting on close approach. Every auto-pick still feeds the combo streak \u2192 reaching x5 multiplier becomes much more achievable in the heat of a magnet window.

## Code
- New: `PowerUps/MagnetCarrot.cs` (PowerUpBase)
- New: `PowerUps/MagnetEffect.cs` (runtime carrier on the rabbit; static `Active` exposes remaining time)
- `Player/RabbitController.cs` \u2014 extracted `NotifyCarrotCollected(go)` so manual + magnet pickups share one code path (events, score, combo all fire identically)
- `World/ChunkManager.cs` \u2014 magnetCarrotChance 0.18, integrated into the mutually-exclusive spawn roll, suppressed while a magnet is already active
- `Core/CheatConsole.cs` \u2014 `magnet` command + help
- `UI/GameHUD.cs` \u2014 gold timer bar (top-right under score) with countdown
- `Core/DebugOverlay.cs` \u2014 magnet status line
- `README.md` \u2014 power-up table, features, cheats

## Feel notes
- Homing speed ramps **6 \u2192 28 u/s** via t\u00b2 curve so close carrots whip in dramatically while distant ones drift in. Per-carrot momentum tracking prevents jitter.
- Magnet **does not** auto-grab other power-up carrots \u2014 the player still chooses which special to take.
- Refresh-on-pickup (extends duration) rather than stacking multiple effects.
- Real hits / death immediately end the effect.