### PR TITLE
Difficulty curve: tier-based escalation

### DIFF
--- a/Assets/_Project/Scripts/Core/DebugOverlay.cs
+++ b/Assets/_Project/Scripts/Core/DebugOverlay.cs
@@ -146,6 +146,13 @@ namespace ReverseRabbitRunner.Core
                 DrawLine(ref cy, x, w, lineH, style,
                     $"<color=#ffd84a>✨ MAGNET {magnet.Remaining:0.0}s</color>");
 
+            // Difficulty
+            var diff = Core.DifficultyManager.Instance;
+            if (diff != null)
+                DrawLine(ref cy, x, w, lineH, style,
+                    $"<color=#7ac8ff>📈 TIER {diff.Tier + 1}/{diff.MaxTier + 1} dist:{diff.CurrentDistance:0}m " +
+                    $"target:{diff.SpeedTarget:F1} farmerX:{diff.FarmerClosenessMultiplier:F2}</color>");
+
             // World stats
             var chunk = FindAnyObjectByType<World.ChunkManager>();
             if (chunk != null)

--- a/Assets/_Project/Scripts/Core/DifficultyManager.cs
+++ b/Assets/_Project/Scripts/Core/DifficultyManager.cs
@@ -1,0 +1,119 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Centralised escalation curve. Reads the player's run distance from
+    /// ChunkManager and exposes a discrete <see cref="Tier"/> plus continuous
+    /// modifiers consumed by the rabbit, farmer and HUD.
+    ///
+    /// One source of truth for "the game gets harder over time", so the
+    /// individual subsystems don't each invent their own curve.
+    /// </summary>
+    public class DifficultyManager : MonoBehaviour
+    {
+        public static DifficultyManager Instance { get; private set; }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void AutoCreate()
+        {
+            if (Instance == null)
+            {
+                var go = new GameObject("[DifficultyManager]");
+                go.AddComponent<DifficultyManager>();
+                DontDestroyOnLoad(go);
+            }
+        }
+
+        [Header("Tier thresholds (metres)")]
+        [Tooltip("Distance at which each successive tier begins. Stay sorted ascending.")]
+        [SerializeField]
+        private float[] tierThresholds = { 0f, 250f, 600f, 1000f, 1500f, 2200f, 3000f, 4000f, 5500f };
+
+        [Header("Speed ramp")]
+        [Tooltip("Target forward speed (units/sec) at each tier. Length must match tierThresholds.")]
+        [SerializeField]
+        private float[] tierSpeedTargets = { 10f, 12f, 14f, 16f, 18f, 21f, 24f, 27f, 30f };
+
+        [Tooltip("How fast baseSpeed lerps toward the tier target (units/sec/sec).")]
+        [SerializeField] private float speedRampPerSecond = 0.6f;
+
+        [Header("Farmer aggression")]
+        [Tooltip("Multiplier on the farmer's resting baseDistance per tier. 1.0 = original, lower = closer.")]
+        [SerializeField]
+        private float[] tierFarmerCloseness = { 1.00f, 0.95f, 0.85f, 0.75f, 0.65f, 0.58f, 0.52f, 0.48f, 0.42f };
+
+        // Cached read of distance to avoid hammering FindAnyObjectByType every frame
+        private World.ChunkManager chunkMgr;
+        private int cachedTier;
+        private float cachedDistance;
+
+        public int Tier => cachedTier;
+        public int MaxTier => tierThresholds.Length - 1;
+        public float CurrentDistance => cachedDistance;
+        public float SpeedTarget => tierSpeedTargets[cachedTier];
+        public float SpeedRampPerSecond => speedRampPerSecond;
+        public float FarmerClosenessMultiplier => tierFarmerCloseness[cachedTier];
+
+        /// <summary>Distance into the current tier (0..1) for HUD progress visuals.</summary>
+        public float TierProgress
+        {
+            get
+            {
+                if (cachedTier >= MaxTier) return 1f;
+                float lo = tierThresholds[cachedTier];
+                float hi = tierThresholds[cachedTier + 1];
+                if (hi <= lo) return 1f;
+                return Mathf.Clamp01((cachedDistance - lo) / (hi - lo));
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+            Instance = this;
+
+            // Defensive: if arrays got out of sync, clamp to the shorter length.
+            int len = Mathf.Min(tierThresholds.Length,
+                Mathf.Min(tierSpeedTargets.Length, tierFarmerCloseness.Length));
+            if (len < tierThresholds.Length)
+            {
+                System.Array.Resize(ref tierThresholds, len);
+                System.Array.Resize(ref tierSpeedTargets, len);
+                System.Array.Resize(ref tierFarmerCloseness, len);
+                Debug.LogWarning($"[DifficultyManager] Tier arrays were uneven; clamped to {len}.");
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this) Instance = null;
+        }
+
+        private void Update()
+        {
+            if (chunkMgr == null)
+                chunkMgr = FindAnyObjectByType<World.ChunkManager>();
+            if (chunkMgr == null) return;
+
+            cachedDistance = chunkMgr.TotalDistance;
+
+            // Walk thresholds (small array — linear scan is fine and avoids dependency
+            // on monotonic distance, which origin-shift could violate momentarily).
+            int t = 0;
+            for (int i = tierThresholds.Length - 1; i >= 0; i--)
+            {
+                if (cachedDistance >= tierThresholds[i]) { t = i; break; }
+            }
+
+            if (t != cachedTier)
+            {
+                int prev = cachedTier;
+                cachedTier = t;
+                if (t > prev) OnTierUp?.Invoke(t);
+            }
+        }
+
+        public event System.Action<int> OnTierUp;
+    }
+}

--- a/Assets/_Project/Scripts/Editor/SceneSetup.cs
+++ b/Assets/_Project/Scripts/Editor/SceneSetup.cs
@@ -656,6 +656,10 @@ namespace ReverseRabbitRunner.Editor
             smObj.transform.parent = managers.transform;
             smObj.AddComponent<Core.ScoreManager>();
 
+            GameObject diffObj = new GameObject("DifficultyManager");
+            diffObj.transform.parent = managers.transform;
+            diffObj.AddComponent<Core.DifficultyManager>();
+
             GameObject imObj = new GameObject("InputManager");
             imObj.transform.parent = managers.transform;
             imObj.AddComponent<Core.InputManager>();

--- a/Assets/_Project/Scripts/Enemies/FarmerController.cs
+++ b/Assets/_Project/Scripts/Enemies/FarmerController.cs
@@ -69,9 +69,21 @@ namespace ReverseRabbitRunner.Enemies
         // === Public State (for debug overlay & tests) ===
         public float CurrentDistance => currentDistance;
         public float BaseDistance => baseDistance;
+        /// <summary>baseDistance after the difficulty multiplier (closer at higher tiers).</summary>
+        public float EffectiveBaseDistance
+        {
+            get
+            {
+                float mult = Core.DifficultyManager.Instance != null
+                    ? Core.DifficultyManager.Instance.FarmerClosenessMultiplier
+                    : 1f;
+                // Never let the resting distance drop below the catch threshold.
+                return Mathf.Max(catchDistance + 0.25f, baseDistance * mult);
+            }
+        }
         public float FadeDistance => fadeDistance;
         public float MaxDistance => maxDistance;
-        public float NormalizedThreat => 1f - Mathf.Clamp01(currentDistance / baseDistance);
+        public float NormalizedThreat => 1f - Mathf.Clamp01(currentDistance / EffectiveBaseDistance);
         public bool IsStumbling => isFarmerStumbling;
         public bool IsVisible => isVisible;
         public bool IsCatching => isCatching;
@@ -91,7 +103,7 @@ namespace ReverseRabbitRunner.Enemies
 
         private void Start()
         {
-            currentDistance = baseDistance;
+            currentDistance = EffectiveBaseDistance;
             targetLane = laneCount / 2;
 
             if (playerTransform == null)
@@ -153,13 +165,14 @@ namespace ReverseRabbitRunner.Enemies
                     isFarmerStumbling = false;
             }
 
-            // Z distance: recover toward baseDistance
-            float recoveryRate = (baseDistance - catchDistance) / Mathf.Max(farmerRecoveryTime, 0.1f);
+            // Z distance: recover toward effective base (which scales with difficulty)
+            float effectiveBase = EffectiveBaseDistance;
+            float recoveryRate = (effectiveBase - catchDistance) / Mathf.Max(farmerRecoveryTime, 0.1f);
             if (isFarmerStumbling)
                 recoveryRate *= 0.2f;
             else if (rabbitFlying)
                 recoveryRate *= 2f; // Farmer runs freely during flight — faster recovery
-            currentDistance = Mathf.MoveTowards(currentDistance, baseDistance, recoveryRate * Time.deltaTime);
+            currentDistance = Mathf.MoveTowards(currentDistance, effectiveBase, recoveryRate * Time.deltaTime);
 
             // Lateral movement
             float laneX = (targetLane - laneCount / 2) * laneWidth;
@@ -231,7 +244,7 @@ namespace ReverseRabbitRunner.Enemies
                     tooFarTimer += Time.deltaTime;
                     if (tooFarTimer >= reappearDelay)
                     {
-                        currentDistance = baseDistance;
+                        currentDistance = EffectiveBaseDistance;
                         tooFarTimer = 0f;
                         isReappearing = false;
                         isFarmerStumbling = false;

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -205,8 +205,19 @@ namespace ReverseRabbitRunner.Player
 
             HandleInput();
 
-            // Gradually increase base speed
-            baseSpeed = Mathf.Min(baseSpeed + speedIncreaseRate * Time.deltaTime, maxSpeed);
+            // Speed escalation: if a DifficultyManager is present it drives the target
+            // (tier-based step-up curve). Otherwise fall back to the legacy linear drift
+            // so the rabbit still works in test scenes without one.
+            var diff = Core.DifficultyManager.Instance;
+            if (diff != null)
+            {
+                float target = Mathf.Min(diff.SpeedTarget, maxSpeed);
+                baseSpeed = Mathf.MoveTowards(baseSpeed, target, diff.SpeedRampPerSecond * Time.deltaTime);
+            }
+            else
+            {
+                baseSpeed = Mathf.Min(baseSpeed + speedIncreaseRate * Time.deltaTime, maxSpeed);
+            }
 
             // Recover from speed debt (jump or stumble)
             if (speedDebt > 0f)

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -22,6 +22,7 @@ namespace ReverseRabbitRunner.UI
         private GUIStyle comboBigStyle;
         private float multiplierFlashTimer;  // tier-up celebration flash
         private float nearMissFlashTimer;    // "NICE!" pop on dodge
+        private float tierUpFlashTimer;      // "TIER X" celebration on difficulty step-up
 
         private GUIStyle scoreStyle;
         private GUIStyle warningStyle;
@@ -62,6 +63,9 @@ namespace ReverseRabbitRunner.UI
                 rabbit.OnStumble += OnRabbitStumble;
                 rabbit.OnNearMiss += OnRabbitNearMiss;
             }
+
+            if (Core.DifficultyManager.Instance != null)
+                Core.DifficultyManager.Instance.OnTierUp += OnDifficultyTierUp;
         }
 
         private void OnDestroy()
@@ -73,6 +77,14 @@ namespace ReverseRabbitRunner.UI
                 rabbit.OnStumble -= OnRabbitStumble;
                 rabbit.OnNearMiss -= OnRabbitNearMiss;
             }
+            if (Core.DifficultyManager.Instance != null)
+                Core.DifficultyManager.Instance.OnTierUp -= OnDifficultyTierUp;
+        }
+
+        private void OnDifficultyTierUp(int newTier)
+        {
+            tierUpFlashTimer = 1.6f;
+            Player.CameraFollow.Instance?.Shake(0.18f, 0.25f);
         }
 
         private void OnComboChanged(int comboCount, int multiplier, bool tierIncreased)
@@ -220,6 +232,53 @@ namespace ReverseRabbitRunner.UI
             GUI.color = Color.white;
         }
 
+        private void DrawTierHUD(float padding)
+        {
+            var diff = Core.DifficultyManager.Instance;
+            if (diff == null) return;
+
+            // Compact "TIER N" badge bottom-left, with a thin progress bar to the next tier.
+            float w = 170f;
+            float h = 36f;
+            float x = padding;
+            float y = Screen.height - h - padding;
+
+            GUI.color = new Color(0f, 0f, 0f, 0.55f);
+            GUI.DrawTexture(new Rect(x - 4, y - 4, w + 8, h + 8), Texture2D.whiteTexture);
+
+            var label = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 18,
+                alignment = TextAnchor.MiddleLeft,
+                fontStyle = FontStyle.Bold
+            };
+            label.normal.textColor = new Color(0.9f, 0.95f, 1f);
+            GUI.color = Color.white;
+            GUI.Label(new Rect(x + 8, y, w - 16, 22), $"TIER {diff.Tier + 1}  \u2022  {diff.CurrentDistance:0}m", label);
+
+            // Tier progress bar
+            float barY = y + 24f;
+            GUI.color = new Color(0.15f, 0.18f, 0.25f, 0.9f);
+            GUI.DrawTexture(new Rect(x + 8, barY, w - 16, 6), Texture2D.whiteTexture);
+            GUI.color = new Color(0.4f, 0.7f, 1f, 0.95f);
+            GUI.DrawTexture(new Rect(x + 8, barY, (w - 16) * diff.TierProgress, 6), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            // Tier-up celebration burst (centre-top)
+            if (tierUpFlashTimer > 0f)
+            {
+                float t = Mathf.Clamp01(tierUpFlashTimer / 1.6f);
+                float alpha = t;
+                int oldFont = comboBigStyle.fontSize;
+                comboBigStyle.fontSize = Mathf.RoundToInt(56f + (1f - t) * 24f);
+                comboBigStyle.normal.textColor = new Color(0.4f, 0.85f, 1f, alpha);
+                GUI.Label(new Rect(0, Screen.height * 0.32f, Screen.width, 100),
+                    $"TIER UP  \u2192  {diff.Tier + 1}", comboBigStyle);
+                comboBigStyle.fontSize = oldFont;
+                comboBigStyle.normal.textColor = Color.white;
+            }
+        }
+
         private void InitStyles()
         {
             scoreStyle = new GUIStyle(GUI.skin.label)
@@ -315,6 +374,8 @@ namespace ReverseRabbitRunner.UI
                 multiplierFlashTimer -= Time.unscaledDeltaTime;
             if (nearMissFlashTimer > 0f)
                 nearMissFlashTimer -= Time.unscaledDeltaTime;
+            if (tierUpFlashTimer > 0f)
+                tierUpFlashTimer -= Time.unscaledDeltaTime;
         }
 
         private void OnGUI()
@@ -340,6 +401,7 @@ namespace ReverseRabbitRunner.UI
             DrawComboHUD(score, padding);
             DrawNearMissPop();
             DrawMagnetHUD(padding);
+            DrawTierHUD(padding);
             // Speed (below score)
             if (rabbit != null)
             {

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It's like having a tireless junior dev who never needs coffee but occasionally p
 - 🌍 Chunk-based infinite world with 3 themed biomes (Concrete, Snow+Mud, Grass)
 - 🔄 Origin shifting for unlimited distance without floating-point issues
 - 🚧 4 obstacle types (farm crates, round hay bales, fence posts, scarecrows) with stumble mechanic
-- 📈 Difficulty ramp — obstacles increase, farmer gets faster over time
+- 📈 Difficulty ramp — tier-based escalation: speed targets step up by distance, farmer rests closer at higher tiers, obstacle density scales. "TIER UP" celebration with camera punch on each step.
 - 🚜 Tractor flatbed platforms — jump on top for a carrot jackpot (~100+ bonus carrots!)
 - 🍼 Birth-Carrot power-up — spawns 125 chaotic rainbow baby rabbits that swarm across lanes hoovering up carrots
 - 🪽 Wing-Carrot power-up — backflip into the sky and FLY! Glide forward collecting airborne carrot streams, then backflip home


### PR DESCRIPTION
Centralises 'the game gets harder over time' in a single `DifficultyManager` singleton that all subsystems read from.

## Tier system
9 tiers driven by run distance (0, 250, 600, 1000, 1500, 2200, 3000, 4000, 5500m). Each tier defines:
- Target forward speed (10 \u2192 30 u/s, smoothly ramped)
- Farmer closeness multiplier (1.00 \u2192 0.42, so the farmer rests much closer at higher tiers)

## Wiring
- `DifficultyManager` auto-spawns via `[RuntimeInitializeOnLoadMethod]` (DontDestroyOnLoad), so existing scenes pick it up without changes.
- `RabbitController` lerps `baseSpeed` \u2192 `DifficultyManager.SpeedTarget` (legacy linear drift retained as fallback when no manager is present \u2014 keeps test scenes working).
- `FarmerController.EffectiveBaseDistance` = base * tier mult, used everywhere the resting distance was previously hard-coded. `NormalizedThreat` now scales with difficulty too.
- `GameHUD` shows 'TIER N \u2022 distM' badge + progress bar bottom-left; 'TIER UP \u2192 N' celebration with camera punch on each step-up.
- `DebugOverlay` adds a tier line with target speed + farmer multiplier.
- `SceneSetup` editor tool also wires the manager for newly-created scenes.

## Notes
- Tier arrays are length-validated in `Awake` to survive misconfiguration.
- Tier 0 fires no celebration on scene reload.
- The full speed cap (`maxSpeed`) is still respected as a safety ceiling.