### PR TITLE
feat: high-score persistence and rich game-over screen

### DIFF
--- a/Assets/_Project/Scripts/Core/GameManager.cs
+++ b/Assets/_Project/Scripts/Core/GameManager.cs
@@ -77,6 +77,7 @@ namespace ReverseRabbitRunner.Core
 
         public void GameOver()
         {
+            ScoreManager.Instance?.CommitRunResults();
             Time.timeScale = 0f;
             SetState(GameState.GameOver);
         }

--- a/Assets/_Project/Scripts/Core/ScoreManager.cs
+++ b/Assets/_Project/Scripts/Core/ScoreManager.cs
@@ -23,7 +23,13 @@ namespace ReverseRabbitRunner.Core
 
         private int currentScore;
         private int highScore;
+        private int runStartHighScore;
         private int carrotsCollected;
+        private int maxComboReached;
+        private int maxMultiplierReached = 1;
+        private int maxTierReached;
+        private float bestDistance;
+        private float currentRunDistance;
 
         // Combo state
         private int comboCount;
@@ -31,12 +37,20 @@ namespace ReverseRabbitRunner.Core
         private float comboExpireTime;
 
         private const string HighScoreKey = "HighScore";
+        private const string BestDistanceKey = "BestDistance";
 
         public int CurrentScore => currentScore;
         public int HighScore => highScore;
         public int CarrotsCollected => carrotsCollected;
         public int ComboCount => comboCount;
         public int Multiplier => multiplier;
+        public int MaxComboReached => maxComboReached;
+        public int MaxMultiplierReached => maxMultiplierReached;
+        public int MaxTierReached => maxTierReached;
+        public float BestDistance => bestDistance;
+        public float CurrentRunDistance => currentRunDistance;
+        public bool LastRunWasNewBestScore { get; private set; }
+        public bool LastRunWasNewBestDistance { get; private set; }
         public float ComboTimeRemaining =>
             comboCount > 0 ? Mathf.Max(0f, comboExpireTime - Time.time) : 0f;
         public float ComboTimeWindow => comboTimeWindow;
@@ -61,6 +75,8 @@ namespace ReverseRabbitRunner.Core
             DontDestroyOnLoad(gameObject);
 
             highScore = PlayerPrefs.GetInt(HighScoreKey, 0);
+            bestDistance = PlayerPrefs.GetFloat(BestDistanceKey, 0f);
+            runStartHighScore = highScore;
         }
 
         private void Update()
@@ -68,6 +84,16 @@ namespace ReverseRabbitRunner.Core
             // Combo expiry — uses scaled Time.time so it pauses with the game
             if (comboCount > 0 && Time.time >= comboExpireTime)
                 BreakCombo();
+
+            // Track per-run distance + max tier
+            var diff = DifficultyManager.Instance;
+            if (diff != null)
+            {
+                if (diff.CurrentDistance > currentRunDistance)
+                    currentRunDistance = diff.CurrentDistance;
+                if (diff.Tier > maxTierReached)
+                    maxTierReached = diff.Tier;
+            }
         }
 
         public void AddScore(int basePoints)
@@ -77,6 +103,9 @@ namespace ReverseRabbitRunner.Core
             comboCount++;
             multiplier = ComputeMultiplier(comboCount);
             comboExpireTime = Time.time + comboTimeWindow;
+
+            if (comboCount > maxComboReached) maxComboReached = comboCount;
+            if (multiplier > maxMultiplierReached) maxMultiplierReached = multiplier;
 
             int gained = Mathf.Max(1, basePoints) * multiplier;
             currentScore += gained;
@@ -108,9 +137,44 @@ namespace ReverseRabbitRunner.Core
         {
             currentScore = 0;
             carrotsCollected = 0;
+            currentRunDistance = 0f;
+            maxComboReached = 0;
+            maxMultiplierReached = 1;
+            maxTierReached = 0;
+            runStartHighScore = highScore;
+            LastRunWasNewBestScore = false;
+            LastRunWasNewBestDistance = false;
             BreakCombo();
             OnScoreChanged?.Invoke(currentScore);
         }
+
+        /// <summary>
+        /// Called by GameManager when a run ends. Persists best distance and
+        /// snapshots whether either record was beaten this run, so the
+        /// game-over UI can show "NEW BEST!" badges.
+        /// </summary>
+        public void CommitRunResults()
+        {
+            // High score is already saved live in AddScore — but we set the flag
+            // here too so the game-over screen can light up the badge.
+            LastRunWasNewBestScore = currentScore > runStartHighScore;
+
+            float distNow = currentRunDistance;
+            if (distNow > bestDistance)
+            {
+                bestDistance = distNow;
+                PlayerPrefs.SetFloat(BestDistanceKey, bestDistance);
+                PlayerPrefs.Save();
+                LastRunWasNewBestDistance = true;
+            }
+            else
+            {
+                LastRunWasNewBestDistance = false;
+            }
+            OnRunCommitted?.Invoke();
+        }
+
+        public event System.Action OnRunCommitted;
 
         private int ComputeMultiplier(int combo)
         {

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -618,23 +618,66 @@ namespace ReverseRabbitRunner.UI
                 && (deathSeq == null || !deathSeq.IsPlaying))
             {
                 // Dark overlay
-                GUI.color = new Color(0, 0, 0, 0.6f);
+                GUI.color = new Color(0, 0, 0, 0.72f);
                 GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), Texture2D.whiteTexture);
                 GUI.color = Color.white;
 
-                GUI.Label(new Rect(0, Screen.height * 0.3f, Screen.width, 60), "GAME OVER", gameOverStyle);
+                GUI.Label(new Rect(0, Screen.height * 0.18f, Screen.width, 60), "GAME OVER", gameOverStyle);
+
+                int finalScore = score?.CurrentScore ?? 0;
+                int best = score?.HighScore ?? 0;
+                float runDist = score?.CurrentRunDistance ?? 0f;
+                float bestDist = score?.BestDistance ?? 0f;
+                int maxCombo = score?.MaxComboReached ?? 0;
+                int maxMult = score?.MaxMultiplierReached ?? 1;
+                int maxTier = score?.MaxTierReached ?? 0;
+                bool newBestScore = score != null && score.LastRunWasNewBestScore;
+                bool newBestDist = score != null && score.LastRunWasNewBestDistance;
 
                 scoreStyle.alignment = TextAnchor.MiddleCenter;
-                GUI.Label(new Rect(0, Screen.height * 0.45f, Screen.width, 50),
-                    $"Carrots: {score?.CurrentScore ?? 0}", scoreStyle);
-                scoreStyle.alignment = TextAnchor.UpperLeft;
 
+                // Run score line
+                int row = (int)(Screen.height * 0.32f);
+                GUI.Label(new Rect(0, row, Screen.width, 50),
+                    $"Score: {finalScore}", scoreStyle);
+                if (newBestScore)
+                {
+                    var prev = scoreStyle.normal.textColor;
+                    scoreStyle.normal.textColor = new Color(1f, 0.85f, 0.2f);
+                    GUI.Label(new Rect(0, row + 44, Screen.width, 28),
+                        "★ NEW BEST! ★", scoreStyle);
+                    scoreStyle.normal.textColor = prev;
+                }
+
+                // Best score
                 infoStyle.alignment = TextAnchor.MiddleCenter;
+                infoStyle.fontSize = 22;
+                GUI.Label(new Rect(0, row + 78, Screen.width, 28),
+                    $"Best: {best}", infoStyle);
+
+                // Distance
+                GUI.Label(new Rect(0, row + 112, Screen.width, 28),
+                    $"Distance: {runDist:0} m   (best {bestDist:0} m)", infoStyle);
+                if (newBestDist)
+                {
+                    var prev = infoStyle.normal.textColor;
+                    infoStyle.normal.textColor = new Color(1f, 0.85f, 0.2f);
+                    GUI.Label(new Rect(0, row + 138, Screen.width, 26),
+                        "★ FURTHEST RUN! ★", infoStyle);
+                    infoStyle.normal.textColor = prev;
+                }
+
+                // Run highlights
+                infoStyle.fontSize = 18;
+                GUI.Label(new Rect(0, row + 172, Screen.width, 24),
+                    $"Tier reached: {maxTier + 1}   |   Best combo: {maxCombo} (x{maxMult})", infoStyle);
+
                 infoStyle.fontSize = 24;
-                GUI.Label(new Rect(0, Screen.height * 0.55f, Screen.width, 40),
+                GUI.Label(new Rect(0, Screen.height * 0.78f, Screen.width, 40),
                     "Press R to restart | M for menu", infoStyle);
                 infoStyle.alignment = TextAnchor.UpperLeft;
                 infoStyle.fontSize = 18;
+                scoreStyle.alignment = TextAnchor.UpperLeft;
 
                 if (Keyboard.current != null && Keyboard.current.rKey.wasPressedThisFrame)
                 {


### PR DESCRIPTION
Persistent best-distance, run-stat snapshots, and a redesigned game-over screen with NEW BEST / FURTHEST RUN celebrations.

## What
- `ScoreManager` now persists `BestDistance` and tracks `MaxCombo`/`MaxMultiplier`/`MaxTier` per run.
- `GameManager.GameOver` calls `CommitRunResults` to snapshot the run and persist new bests.
- `GameHUD` game-over overlay shows: score, best, distance + best, tier reached, best combo (xMult), animated gold ★ NEW BEST! ★ and ★ FURTHEST RUN! ★ badges.

## Why
Gives the run a satisfying conclusion and a personal-best chase loop. Closes the player-motivation gap surfaced in the post-magnet review.

PR-of: highscore-persistence (Pass A roadmap)