### PR TITLE
feat: procedural audio juice (combo, magnet, near-miss, fanfare)

### DIFF
--- a/Assets/_Project/Scripts/Core/AudioManager.cs
+++ b/Assets/_Project/Scripts/Core/AudioManager.cs
@@ -51,6 +51,9 @@ namespace ReverseRabbitRunner.Core
         private Transform cachedFarmer;
         private bool wasGrounded = true;
         private bool subscribedToRabbit;
+        private bool subscribedToScore;
+        private bool subscribedToGame;
+        private bool subscribedToMagnet;
 
         private void Awake()
         {
@@ -141,6 +144,9 @@ namespace ReverseRabbitRunner.Core
         private void Start()
         {
             TrySubscribeToRabbit();
+            TrySubscribeToScore();
+            TrySubscribeToGame();
+            TrySubscribeToMagnet();
         }
 
         private void Update()
@@ -152,6 +158,9 @@ namespace ReverseRabbitRunner.Core
                 if (cachedRabbit == null) subscribedToRabbit = false;
                 TrySubscribeToRabbit();
             }
+            if (!subscribedToScore) TrySubscribeToScore();
+            if (!subscribedToGame) TrySubscribeToGame();
+            if (!subscribedToMagnet) TrySubscribeToMagnet();
 
             // Detect landing (was airborne, now grounded)
             if (cachedRabbit != null && cachedRabbit.IsAlive)
@@ -178,7 +187,31 @@ namespace ReverseRabbitRunner.Core
 
             cachedRabbit.OnCollectCarrot += OnCollectCarrot;
             cachedRabbit.OnStumble += OnStumble;
+            cachedRabbit.OnNearMiss += OnNearMiss;
             subscribedToRabbit = true;
+        }
+
+        private void TrySubscribeToScore()
+        {
+            var score = ScoreManager.Instance;
+            if (score == null) return;
+            score.OnComboChanged += OnComboChanged;
+            subscribedToScore = true;
+        }
+
+        private void TrySubscribeToGame()
+        {
+            var game = GameManager.Instance;
+            if (game == null) return;
+            game.OnGameStateChanged += OnGameStateChanged;
+            subscribedToGame = true;
+        }
+
+        private void TrySubscribeToMagnet()
+        {
+            // Magnet has a static activation hook; subscribe lazily.
+            PowerUps.MagnetEffect.OnMagnetActivated += OnMagnetActivated;
+            subscribedToMagnet = true;
         }
 
         private void OnDestroy()
@@ -189,7 +222,17 @@ namespace ReverseRabbitRunner.Core
             {
                 cachedRabbit.OnCollectCarrot -= OnCollectCarrot;
                 cachedRabbit.OnStumble -= OnStumble;
+                cachedRabbit.OnNearMiss -= OnNearMiss;
             }
+
+            if (subscribedToScore && ScoreManager.Instance != null)
+                ScoreManager.Instance.OnComboChanged -= OnComboChanged;
+
+            if (subscribedToGame && GameManager.Instance != null)
+                GameManager.Instance.OnGameStateChanged -= OnGameStateChanged;
+
+            if (subscribedToMagnet)
+                PowerUps.MagnetEffect.OnMagnetActivated -= OnMagnetActivated;
         }
 
         // --- Event Handlers ---
@@ -259,6 +302,46 @@ namespace ReverseRabbitRunner.Core
             // Use tall stumble sound for big penalties, small for minor
             var clip = penalty >= 3f ? stumbleTall : stumbleSmall;
             PlaySFX(clip, 1f);
+        }
+
+        private void OnNearMiss(GameObject obstacle)
+        {
+            PlaySFX(ProceduralSfx.NearMissWhoosh(), 0.7f);
+        }
+
+        private void OnComboChanged(int comboCount, int multiplier, bool tierUp)
+        {
+            if (!tierUp) return;
+            // multiplier x2 = tier 0, x3 = 1, ...
+            int tierIdx = Mathf.Max(0, multiplier - 2);
+            PlaySFX(ProceduralSfx.ComboTierSting(tierIdx), 0.85f);
+        }
+
+        private void OnMagnetActivated()
+        {
+            PlaySFX(ProceduralSfx.MagnetWhoosh(), 0.85f);
+        }
+
+        private bool gameOverFanfarePending;
+        private void OnGameStateChanged(GameManager.GameState state)
+        {
+            if (state == GameManager.GameState.GameOver)
+            {
+                // Wait one frame to avoid stomping on death stab
+                gameOverFanfarePending = true;
+                StartCoroutine(PlayFanfareDelayed(0.55f));
+            }
+        }
+
+        private System.Collections.IEnumerator PlayFanfareDelayed(float delay)
+        {
+            float t = 0f;
+            while (t < delay) { t += Time.unscaledDeltaTime; yield return null; }
+            if (gameOverFanfarePending)
+            {
+                gameOverFanfarePending = false;
+                PlaySFX(ProceduralSfx.GameOverFanfare(), 0.9f);
+            }
         }
 
         // --- Public Play Methods (called from other scripts) ---

--- a/Assets/_Project/Scripts/Core/ProceduralSfx.cs
+++ b/Assets/_Project/Scripts/Core/ProceduralSfx.cs
@@ -1,0 +1,124 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Tiny on-the-fly synth used to build short SFX clips at runtime so the
+    /// game ships with juicy feedback (combo tier-up sting, magnet whoosh,
+    /// near-miss whoosh, game-over fanfare) without shipping audio assets.
+    ///
+    /// All clips are mono, 22050Hz, hard-cached after first build.
+    /// </summary>
+    public static class ProceduralSfx
+    {
+        private const int SampleRate = 22050;
+
+        private static AudioClip cachedNearMiss;
+        private static AudioClip cachedMagnet;
+        private static AudioClip cachedFanfare;
+        private static readonly AudioClip[] cachedTierStings = new AudioClip[6];
+
+        /// <summary>Sweeping whoosh, descending then rising — used for near-miss.</summary>
+        public static AudioClip NearMissWhoosh()
+        {
+            if (cachedNearMiss != null) return cachedNearMiss;
+            const float duration = 0.30f;
+            int n = Mathf.RoundToInt(duration * SampleRate);
+            var data = new float[n];
+            for (int i = 0; i < n; i++)
+            {
+                float t = i / (float)n;
+                // Filtered noise + sine sweep down 1200→300, up to 800Hz at end
+                float freq = Mathf.Lerp(1200f, 300f, Mathf.Pow(t, 0.6f));
+                if (t > 0.7f) freq = Mathf.Lerp(300f, 800f, (t - 0.7f) / 0.3f);
+                float sine = Mathf.Sin(2f * Mathf.PI * freq * (i / (float)SampleRate));
+                float noise = (Random.value * 2f - 1f) * 0.55f;
+                float env = Mathf.Sin(Mathf.PI * t); // bell envelope
+                data[i] = (sine * 0.55f + noise * 0.45f) * env * 0.6f;
+            }
+            cachedNearMiss = AudioClip.Create("NearMissWhoosh", n, 1, SampleRate, false);
+            cachedNearMiss.SetData(data, 0);
+            return cachedNearMiss;
+        }
+
+        /// <summary>Magnet pickup: shimmery rising chord with a metallic ping.</summary>
+        public static AudioClip MagnetWhoosh()
+        {
+            if (cachedMagnet != null) return cachedMagnet;
+            const float duration = 0.45f;
+            int n = Mathf.RoundToInt(duration * SampleRate);
+            var data = new float[n];
+            // Rising glissando + perfect-fifth
+            for (int i = 0; i < n; i++)
+            {
+                float t = i / (float)n;
+                float baseF = Mathf.Lerp(440f, 880f, t);
+                float fifth = baseF * 1.5f;
+                float ping = Mathf.Sin(2f * Mathf.PI * baseF * 4f * (i / (float)SampleRate))
+                             * Mathf.Exp(-t * 8f) * 0.25f;
+                float a = Mathf.Sin(2f * Mathf.PI * baseF * (i / (float)SampleRate));
+                float b = Mathf.Sin(2f * Mathf.PI * fifth * (i / (float)SampleRate));
+                float env = Mathf.Sin(Mathf.PI * t);
+                data[i] = ((a * 0.5f + b * 0.4f) * env + ping) * 0.55f;
+            }
+            cachedMagnet = AudioClip.Create("MagnetWhoosh", n, 1, SampleRate, false);
+            cachedMagnet.SetData(data, 0);
+            return cachedMagnet;
+        }
+
+        /// <summary>Short triumphant sting — pitch climbs with combo tier (0..5).</summary>
+        public static AudioClip ComboTierSting(int tierIndex)
+        {
+            tierIndex = Mathf.Clamp(tierIndex, 0, cachedTierStings.Length - 1);
+            if (cachedTierStings[tierIndex] != null) return cachedTierStings[tierIndex];
+
+            // Major-third stack: each tier shifts up a major third (1.26x)
+            float root = 330f * Mathf.Pow(1.26f, tierIndex);
+            float duration = 0.26f;
+            int n = Mathf.RoundToInt(duration * SampleRate);
+            var data = new float[n];
+            for (int i = 0; i < n; i++)
+            {
+                float t = i / (float)n;
+                float a = Mathf.Sin(2f * Mathf.PI * root * (i / (float)SampleRate));
+                float b = Mathf.Sin(2f * Mathf.PI * root * 1.26f * (i / (float)SampleRate));
+                float c = Mathf.Sin(2f * Mathf.PI * root * 1.5f * (i / (float)SampleRate));
+                float env = Mathf.Exp(-t * 5f) * (1f - Mathf.Exp(-t * 60f)); // pluck
+                data[i] = (a * 0.5f + b * 0.35f + c * 0.3f) * env * 0.55f;
+            }
+            var clip = AudioClip.Create($"ComboSting_{tierIndex}", n, 1, SampleRate, false);
+            clip.SetData(data, 0);
+            cachedTierStings[tierIndex] = clip;
+            return clip;
+        }
+
+        /// <summary>Two-bar mournful descending fanfare for game-over screen.</summary>
+        public static AudioClip GameOverFanfare()
+        {
+            if (cachedFanfare != null) return cachedFanfare;
+            // Notes: G4, E4, C4, A3 (descending sigh) - 0.35s each
+            float[] freqs = { 392f, 330f, 262f, 220f };
+            float noteDur = 0.32f;
+            int notes = freqs.Length;
+            int total = Mathf.RoundToInt(noteDur * notes * SampleRate);
+            var data = new float[total];
+            int notLen = Mathf.RoundToInt(noteDur * SampleRate);
+            for (int n_i = 0; n_i < notes; n_i++)
+            {
+                float f = freqs[n_i];
+                int offset = n_i * notLen;
+                for (int i = 0; i < notLen; i++)
+                {
+                    float t = i / (float)notLen;
+                    float s = Mathf.Sin(2f * Mathf.PI * f * (i / (float)SampleRate));
+                    float oct = Mathf.Sin(2f * Mathf.PI * f * 0.5f * (i / (float)SampleRate));
+                    float env = Mathf.Exp(-t * 3.2f) * (1f - Mathf.Exp(-t * 50f));
+                    data[offset + i] = (s * 0.55f + oct * 0.4f) * env * 0.55f;
+                }
+            }
+            cachedFanfare = AudioClip.Create("GameOverFanfare", total, 1, SampleRate, false);
+            cachedFanfare.SetData(data, 0);
+            return cachedFanfare;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs
+++ b/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs
@@ -30,6 +30,9 @@ namespace ReverseRabbitRunner.PowerUps
         public float Remaining => remaining;
         public float DurationFraction => originalDuration <= 0f ? 0f : Mathf.Clamp01(remaining / originalDuration);
 
+        /// <summary>Fires whenever a magnet is freshly activated or refreshed (for SFX/VFX).</summary>
+        public static event System.Action OnMagnetActivated;
+
         public void Initialize(Player.RabbitController r, float duration, float radiusUnits)
         {
             rabbit = r;
@@ -37,6 +40,7 @@ namespace ReverseRabbitRunner.PowerUps
             originalDuration = duration;
             radius = radiusUnits;
             Active = this;
+            OnMagnetActivated?.Invoke();
         }
 
         public void Refresh(float duration, float radiusUnits)
@@ -45,6 +49,7 @@ namespace ReverseRabbitRunner.PowerUps
             remaining = Mathf.Max(remaining, duration);
             originalDuration = Mathf.Max(originalDuration, duration);
             radius = Mathf.Max(radius, radiusUnits);
+            OnMagnetActivated?.Invoke();
         }
 
         private void Update()


### PR DESCRIPTION
Tiny on-the-fly synth + four new audio cues for the game's high-impact moments. No new audio assets shipped.

## Cues
- **Combo tier-up sting** — pluck on major-third stack, pitch climbs per multiplier.
- **Magnet activation whoosh** — rising glissando + fifth + ping.
- **Near-miss whoosh** — filtered-noise sweep on the existing OnNearMiss event.
- **Game-over fanfare** — 4-note descending sigh, 0.55s after the death stab.

## Wiring
- New `ProceduralSfx` static class generates and caches AudioClips lazily.
- `MagnetEffect` exposes a new static `OnMagnetActivated` event (fires on Initialize and Refresh).
- `AudioManager` subscribes to ScoreManager.OnComboChanged, GameManager.OnGameStateChanged, MagnetEffect.OnMagnetActivated, and RabbitController.OnNearMiss. All cleaned up in OnDestroy.

PR-of: audio-juicing (Pass A roadmap)