### PR TITLE
refactor: cleanup batch (material leaks, input realloc, GUI alpha, camera restore)

### DIFF
--- a/Assets/_Project/Scripts/Core/DeathSequence.cs
+++ b/Assets/_Project/Scripts/Core/DeathSequence.cs
@@ -258,6 +258,15 @@ namespace ReverseRabbitRunner.Core
             isPlaying = false;
             fadeAlpha = 0f; // Clear black overlay so GameHUD game over screen is visible
 
+            // Restore camera so a no-reload restart leaves things sane.
+            if (mainCamera != null)
+            {
+                if (originalCamParent != null)
+                    mainCamera.transform.SetParent(originalCamParent, true);
+                var camFollow = mainCamera.GetComponent<Player.CameraFollow>();
+                if (camFollow != null) camFollow.enabled = true;
+            }
+
             AudioManager.Instance?.PlayGameOver();
             GameManager.Instance?.GameOver();
         }

--- a/Assets/_Project/Scripts/Core/MusicPlayer.cs
+++ b/Assets/_Project/Scripts/Core/MusicPlayer.cs
@@ -238,23 +238,23 @@ namespace ReverseRabbitRunner.Core
                     fontStyle = FontStyle.Italic,
                     alignment = TextAnchor.LowerRight
                 };
-                songNameStyle.normal.textColor = new Color(1f, 1f, 1f, 0.6f);
+                songNameStyle.normal.textColor = Color.white;
             }
 
-            // Fade out the last second
-            float alpha = Mathf.Clamp01(songNameDisplayTimer);
-            if (!showSongName) // Only fade if not in persistent mode
-            {
-                var c = songNameStyle.normal.textColor;
-                c.a = alpha * 0.6f;
-                songNameStyle.normal.textColor = c;
-            }
+            // Fade out the last second using GUI.color so we don't mutate the
+            // style's textColor every frame (which accumulates float error and
+            // can leave the label permanently dim after a fade).
+            float alpha = showSongName ? 0.6f : Mathf.Clamp01(songNameDisplayTimer) * 0.6f;
+            var prev = GUI.color;
+            GUI.color = new Color(1f, 1f, 1f, alpha);
 
             GUI.Label(
                 new Rect(0, Screen.height - 40, Screen.width - 15, 30),
                 $"♫ {currentTrackName}",
                 songNameStyle
             );
+
+            GUI.color = prev;
         }
 
         // --- Volume Control ---

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -102,6 +102,7 @@ namespace ReverseRabbitRunner.Player
             if (body != null) bodyTransform = body;
 
             BuildNearMissZone();
+            BuildInputActions();
         }
 
         private void BuildNearMissZone()
@@ -134,9 +135,10 @@ namespace ReverseRabbitRunner.Player
             detector.OnNearMiss += go => OnNearMiss?.Invoke(go);
         }
 
-        private void OnEnable()
+        private void BuildInputActions()
         {
-            // Lane switching input
+            // Lane switching input — built once at Awake, enabled/disabled
+            // by OnEnable/OnDisable to avoid per-cycle allocation churn.
             moveAction = new InputAction("Move", InputActionType.Value);
             moveAction.AddCompositeBinding("1DAxis")
                 .With("Negative", "<Keyboard>/a")
@@ -150,22 +152,29 @@ namespace ReverseRabbitRunner.Player
             moveAction.AddCompositeBinding("1DAxis")
                 .With("Negative", "<Gamepad>/dpad/left")
                 .With("Positive", "<Gamepad>/dpad/right");
-            moveAction.Enable();
 
-            // Jump input
             jumpAction = new InputAction("Jump", InputActionType.Button);
             jumpAction.AddBinding("<Keyboard>/space");
             jumpAction.AddBinding("<Keyboard>/w");
             jumpAction.AddBinding("<Keyboard>/upArrow");
             jumpAction.AddBinding("<Gamepad>/buttonSouth");
-            jumpAction.Enable();
+        }
+
+        private void OnEnable()
+        {
+            moveAction?.Enable();
+            jumpAction?.Enable();
         }
 
         private void OnDisable()
         {
             moveAction?.Disable();
-            moveAction?.Dispose();
             jumpAction?.Disable();
+        }
+
+        private void OnDestroy()
+        {
+            moveAction?.Dispose();
             jumpAction?.Dispose();
         }
 

--- a/Assets/_Project/Scripts/PowerUps/FlightController.cs
+++ b/Assets/_Project/Scripts/PowerUps/FlightController.cs
@@ -20,6 +20,8 @@ namespace ReverseRabbitRunner.PowerUps
         private Quaternion preFlightRotation;
         private FlightPhase phase;
         private GameObject carrotStreamParent;
+        private Material sharedCarrotMat;
+        private Material sharedLeavesMat;
 
         private enum FlightPhase { TransitionUp, Flying, TransitionDown }
 
@@ -153,8 +155,8 @@ namespace ReverseRabbitRunner.PowerUps
             int laneCount = 5;
 
             var urpLit = Shader.Find("Universal Render Pipeline/Lit");
-            Material carrotMat = MakeMat(new Color(1f, 0.5f, 0.05f), urpLit);
-            Material leavesMat = MakeMat(new Color(0.1f, 0.6f, 0.1f), urpLit);
+            sharedCarrotMat = MakeMat(new Color(1f, 0.5f, 0.05f), urpLit);
+            sharedLeavesMat = MakeMat(new Color(0.1f, 0.6f, 0.1f), urpLit);
 
             for (int i = 0; i < carrotCount; i++)
             {
@@ -178,7 +180,7 @@ namespace ReverseRabbitRunner.PowerUps
                 carrot.transform.position = new Vector3(x, flightHeight + 0.44f, z);
                 carrot.transform.localScale = new Vector3(0.34f, 0.68f, 0.34f);
                 carrot.transform.rotation = Quaternion.Euler(0, 0, 180f);
-                carrot.GetComponent<Renderer>().material = carrotMat;
+                carrot.GetComponent<Renderer>().sharedMaterial = sharedCarrotMat;
                 carrot.GetComponent<Collider>().isTrigger = true;
 
                 var leaves = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -187,7 +189,7 @@ namespace ReverseRabbitRunner.PowerUps
                 leaves.transform.localPosition = new Vector3(0, -0.7f, 0);
                 leaves.transform.localScale = new Vector3(2f, 0.3f, 2f);
                 Object.DestroyImmediate(leaves.GetComponent<Collider>());
-                leaves.GetComponent<Renderer>().material = leavesMat;
+                leaves.GetComponent<Renderer>().sharedMaterial = sharedLeavesMat;
             }
 
             Debug.Log($"[Flight] Spawned {carrotCount} sky carrots across {numChanges + 1} lane segments");
@@ -207,6 +209,9 @@ namespace ReverseRabbitRunner.PowerUps
 
             if (carrotStreamParent != null)
                 Destroy(carrotStreamParent);
+
+            if (sharedCarrotMat != null) { Destroy(sharedCarrotMat); sharedCarrotMat = null; }
+            if (sharedLeavesMat != null) { Destroy(sharedLeavesMat); sharedLeavesMat = null; }
 
             Debug.Log("[Flight] Flight complete — back to backwards running!");
             Destroy(this);


### PR DESCRIPTION
Bundled fixes from the post-magnet code review:

- FlightController: switched per-spawn `Renderer.material` to `sharedMaterial` (one carrot/leaves material instead of N clones), and Destroy() both in Cleanup.
- RabbitController: moved InputAction construction to Awake (deduplicated double-Awake), Enable/Disable on toggle, Dispose only on destroy.
- MusicPlayer: replaced cumulative `style.normal.textColor.a` mutation with `GUI.color` modulation — fixes the song-name label going permanently dim after a fade.
- DeathSequence: re-parents the main camera and re-enables CameraFollow after fadeout, so non-reload restarts don't end up with an orphaned camera.

PR-of: cleanup-batch (Pass C roadmap)