### PR TITLE
feat(easter-egg): Konami code → Golden Rabbit Mode

### DIFF
--- a/Assets/_Project/Scripts/Core/EasterEggs.cs
+++ b/Assets/_Project/Scripts/Core/EasterEggs.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Centralised registry for hidden cheats / easter eggs. PlayerPrefs-backed.
+    /// Currently implements the "Golden Rabbit" cheat unlocked by the Konami
+    /// code on the title screen.
+    ///
+    /// Design notes:
+    ///   * All state lives in PlayerPrefs so it survives sessions.
+    ///   * State is exposed through static properties; setters persist
+    ///     immediately because toggles are rare button-style events.
+    ///   * Visual / score systems read state lazily — they don't need to be
+    ///     wired together. ScoreManager multiplies by ScoreBonusMultiplier;
+    ///     RabbitController tints body materials when GoldenRabbitUnlocked.
+    /// </summary>
+    public static class EasterEggs
+    {
+        private const string GoldenRabbitKey = "EE_GoldenRabbit";
+
+        /// <summary>Score multiplier applied while the cheat is on.</summary>
+        public const float GoldenRabbitScoreBonus = 1.5f;
+
+        /// <summary>Tint applied to the rabbit body when the cheat is on.</summary>
+        public static readonly Color GoldenRabbitTint = new Color(1f, 0.82f, 0.18f);
+
+        /// <summary>Raised whenever the Golden Rabbit flag changes value.</summary>
+        public static event Action<bool> OnGoldenRabbitChanged;
+
+        public static bool GoldenRabbitUnlocked
+        {
+            get => PlayerPrefs.GetInt(GoldenRabbitKey, 0) == 1;
+            set
+            {
+                bool current = GoldenRabbitUnlocked;
+                if (current == value) return;
+                PlayerPrefs.SetInt(GoldenRabbitKey, value ? 1 : 0);
+                PlayerPrefs.Save();
+                OnGoldenRabbitChanged?.Invoke(value);
+            }
+        }
+
+        /// <summary>Score multiplier — 1f when no cheats active.</summary>
+        public static float ScoreBonusMultiplier => GoldenRabbitUnlocked ? GoldenRabbitScoreBonus : 1f;
+    }
+}

--- a/Assets/_Project/Scripts/Core/KonamiCodeDetector.cs
+++ b/Assets/_Project/Scripts/Core/KonamiCodeDetector.cs
@@ -1,0 +1,148 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Detects the Konami code (↑ ↑ ↓ ↓ ← → ← → B A) on the keyboard. On a
+    /// successful entry, toggles <see cref="EasterEggs.GoldenRabbitUnlocked"/>
+    /// and emits a brief on-screen toast.
+    ///
+    /// Runs everywhere — auto-spawned at runtime as a DontDestroyOnLoad
+    /// singleton, so the cheat is always discoverable. Implementation is
+    /// timing-tolerant (no per-step deadline) but resets the sequence on the
+    /// first wrong key press, preventing accidental fragments from arming the
+    /// cheat. Uses the new Input System exclusively (Input System package is
+    /// already a dependency).
+    /// </summary>
+    public class KonamiCodeDetector : MonoBehaviour
+    {
+        private static KonamiCodeDetector instance;
+
+        private static readonly Key[] Sequence =
+        {
+            Key.UpArrow,    Key.UpArrow,
+            Key.DownArrow,  Key.DownArrow,
+            Key.LeftArrow,  Key.RightArrow,
+            Key.LeftArrow,  Key.RightArrow,
+            Key.B,          Key.A,
+        };
+
+        private int progress;
+        private float toastUntilTime;
+        private string toastMessage;
+        private GUIStyle toastStyle;
+        private float lastKeyTime;
+        private const float SequenceTimeoutSeconds = 4f; // resets if user pauses too long
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (instance != null) return;
+            var go = new GameObject("[KonamiCodeDetector]");
+            DontDestroyOnLoad(go);
+            instance = go.AddComponent<KonamiCodeDetector>();
+        }
+
+        private void Update()
+        {
+            var kb = Keyboard.current;
+            if (kb == null) return;
+
+            // Time-based reset — keeps fragments from accumulating across long sessions.
+            if (progress > 0 && Time.unscaledTime - lastKeyTime > SequenceTimeoutSeconds)
+                progress = 0;
+
+            // Find the single key pressed this frame (if any). We only consider
+            // keys present in the sequence so other typing doesn't reset us
+            // every keystroke — but if a SEQUENCE-key is pressed wrongly, that
+            // does reset, which is the correct UX for a code.
+            Key pressed = Key.None;
+            for (int i = 0; i < AllRelevantKeys.Length; i++)
+            {
+                var k = AllRelevantKeys[i];
+                if (kb[k].wasPressedThisFrame) { pressed = k; break; }
+            }
+            if (pressed == Key.None) return;
+
+            lastKeyTime = Time.unscaledTime;
+
+            if (pressed == Sequence[progress])
+            {
+                progress++;
+                if (progress >= Sequence.Length)
+                {
+                    progress = 0;
+                    OnSequenceComplete();
+                }
+            }
+            else
+            {
+                // Restart, but allow the wrong key to count if it matches the
+                // sequence's first step (common case: user starts over).
+                progress = (pressed == Sequence[0]) ? 1 : 0;
+            }
+        }
+
+        // The set of keys we listen for at all. Pressing anything outside this
+        // set leaves the sequence progress untouched, so normal typing in
+        // text fields won't break the code halfway through.
+        private static readonly Key[] AllRelevantKeys =
+        {
+            Key.UpArrow, Key.DownArrow, Key.LeftArrow, Key.RightArrow, Key.A, Key.B,
+        };
+
+        private void OnSequenceComplete()
+        {
+            bool nowOn = !EasterEggs.GoldenRabbitUnlocked;
+            EasterEggs.GoldenRabbitUnlocked = nowOn;
+
+            toastMessage = nowOn
+                ? "✨🥕 GOLDEN RABBIT MODE — UNLOCKED 🥕✨\n+50% score • restart run to see the tint"
+                : "Golden Rabbit Mode — OFF";
+            toastUntilTime = Time.unscaledTime + 3.5f;
+
+            // Best-effort SFX feedback — manager may be absent in main menu.
+            AudioManager.Instance?.PlayMenuClick();
+        }
+
+        private void OnGUI()
+        {
+            if (Time.unscaledTime > toastUntilTime || string.IsNullOrEmpty(toastMessage))
+                return;
+
+            if (toastStyle == null)
+            {
+                toastStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fontSize = 26,
+                    alignment = TextAnchor.MiddleCenter,
+                    fontStyle = FontStyle.Bold,
+                    wordWrap = true,
+                };
+            }
+
+            // Fade-out in the last 0.6s.
+            float remaining = toastUntilTime - Time.unscaledTime;
+            float alpha = Mathf.Clamp01(remaining / 0.6f);
+            Color prev = GUI.color;
+            GUI.color = new Color(1f, 0.85f, 0.2f, alpha);
+
+            // Drop-shadow for readability against any background.
+            var rect = new Rect(0, Screen.height * 0.18f, Screen.width, 80);
+            var shadowRect = new Rect(rect.x + 2, rect.y + 2, rect.width, rect.height);
+            Color shadow = GUI.color;
+            GUI.color = new Color(0f, 0f, 0f, 0.7f * alpha);
+            GUI.Label(shadowRect, toastMessage, toastStyle);
+            GUI.color = shadow;
+            GUI.Label(rect, toastMessage, toastStyle);
+
+            GUI.color = prev;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this) instance = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/ScoreManager.cs
+++ b/Assets/_Project/Scripts/Core/ScoreManager.cs
@@ -107,7 +107,7 @@ namespace ReverseRabbitRunner.Core
             if (comboCount > maxComboReached) maxComboReached = comboCount;
             if (multiplier > maxMultiplierReached) maxMultiplierReached = multiplier;
 
-            int gained = Mathf.Max(1, basePoints) * multiplier;
+            int gained = Mathf.Max(1, Mathf.RoundToInt(Mathf.Max(1, basePoints) * multiplier * EasterEggs.ScoreBonusMultiplier));
             currentScore += gained;
             carrotsCollected++;
             OnScoreChanged?.Invoke(currentScore);

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -103,6 +103,61 @@ namespace ReverseRabbitRunner.Player
 
             BuildNearMissZone();
             BuildInputActions();
+            ApplyEasterEggVisuals();
+        }
+
+        // Materials we created at runtime — destroyed in OnDestroy to avoid leaks.
+        private System.Collections.Generic.List<Material> easterEggMaterials;
+
+        /// <summary>
+        /// Tints the rabbit body / head / paws with a gold sheen when the
+        /// <see cref="Core.EasterEggs.GoldenRabbitUnlocked"/> cheat is active.
+        ///
+        /// Walks every Renderer under the Body container and finds the shared
+        /// <c>Rabbit_Mat</c> material (assigned in <see cref="Editor.SceneSetup"/>).
+        /// We swap that single material for a tinted instance so the head, body
+        /// and limbs all change colour together; eyes / nose / pupils keep their
+        /// original materials. The tint is multiplicative so URP lighting still
+        /// reads correctly.
+        /// </summary>
+        private void ApplyEasterEggVisuals()
+        {
+            if (!Core.EasterEggs.GoldenRabbitUnlocked) return;
+            if (bodyTransform == null) return;
+
+            var renderers = bodyTransform.GetComponentsInChildren<Renderer>(includeInactive: true);
+            if (renderers == null || renderers.Length == 0) return;
+
+            easterEggMaterials = new System.Collections.Generic.List<Material>();
+            Material tintedShared = null;
+
+            foreach (var r in renderers)
+            {
+                if (r == null) continue;
+                var mats = r.sharedMaterials;
+                if (mats == null) continue;
+
+                bool changed = false;
+                for (int i = 0; i < mats.Length; i++)
+                {
+                    var m = mats[i];
+                    if (m == null) continue;
+                    if (!m.name.StartsWith("Rabbit_Mat")) continue;
+
+                    if (tintedShared == null)
+                    {
+                        tintedShared = new Material(m) { name = "Rabbit_Mat_Golden" };
+                        if (tintedShared.HasProperty("_BaseColor"))
+                            tintedShared.SetColor("_BaseColor", Core.EasterEggs.GoldenRabbitTint);
+                        else
+                            tintedShared.color = Core.EasterEggs.GoldenRabbitTint;
+                        easterEggMaterials.Add(tintedShared);
+                    }
+                    mats[i] = tintedShared;
+                    changed = true;
+                }
+                if (changed) r.sharedMaterials = mats;
+            }
         }
 
         private void BuildNearMissZone()
@@ -176,6 +231,13 @@ namespace ReverseRabbitRunner.Player
         {
             moveAction?.Dispose();
             jumpAction?.Dispose();
+
+            if (easterEggMaterials != null)
+            {
+                for (int i = 0; i < easterEggMaterials.Count; i++)
+                    if (easterEggMaterials[i] != null) Destroy(easterEggMaterials[i]);
+                easterEggMaterials = null;
+            }
         }
 
         private void Update()

--- a/Assets/_Project/Scripts/UI/MainMenuUI.cs
+++ b/Assets/_Project/Scripts/UI/MainMenuUI.cs
@@ -16,6 +16,7 @@ namespace ReverseRabbitRunner.UI
         private Slider sfxSlider;
         private Slider musicSlider;
         private Text deathFxButtonLabel;
+        private Text goldenIndicator;
 
         private void Start()
         {
@@ -28,6 +29,19 @@ namespace ReverseRabbitRunner.UI
             AudioListener.volume = PlayerPrefs.GetFloat("MasterVolume", 1f);
 
             BuildUI();
+
+            Core.EasterEggs.OnGoldenRabbitChanged += OnGoldenRabbitChanged;
+        }
+
+        private void OnDestroy()
+        {
+            Core.EasterEggs.OnGoldenRabbitChanged -= OnGoldenRabbitChanged;
+        }
+
+        private void OnGoldenRabbitChanged(bool unlocked)
+        {
+            if (goldenIndicator != null)
+                goldenIndicator.gameObject.SetActive(unlocked);
         }
 
         private void BuildUI()
@@ -55,6 +69,14 @@ namespace ReverseRabbitRunner.UI
             // Subtitle
             CreateText(canvasObj.transform, "Subtitle", "Run backwards. Trust your mirrors.",
                 new Vector2(0, 120), 24, new Color(0.7f, 0.7f, 0.7f));
+
+            // Easter-egg indicator — created once and shown/hidden in response
+            // to the Konami toggle event. Stays in sync if user activates the
+            // cheat while sitting on the title screen.
+            goldenIndicator = CreateText(canvasObj.transform, "GoldenIndicator",
+                "★ GOLDEN RABBIT ENGAGED ★", new Vector2(0, 85), 18,
+                new Color(1f, 0.82f, 0.18f), FontStyle.Bold);
+            goldenIndicator.gameObject.SetActive(Core.EasterEggs.GoldenRabbitUnlocked);
 
             // Buttons
             CreateButton(canvasObj.transform, "PlayButton", "▶  PLAY", new Vector2(0, 0), OnPlay,


### PR DESCRIPTION
🥕 *(spoilers below — close this if you want to discover it organically!)*

## The cheat
Enter `↑ ↑ ↓ ↓ ← → ← → B A` on the keyboard anywhere in the game to toggle **Golden Rabbit Mode**:
- Gold tint applied to the rabbit body / head / limbs (eyes + nose stay normal)
- 1.5× score multiplier on every carrot pickup
- Subtle ★ indicator on the main menu when active
- 3.5s on-screen toast with fade-out when toggled, and a menu-click chime

## Architecture
- `Core.EasterEggs`: static, PlayerPrefs-backed flag store + score-bonus helper + change event.
- `Core.KonamiCodeDetector`: DontDestroyOnLoad singleton auto-spawned via `RuntimeInitializeOnLoadMethod` so the cheat is discoverable in any scene. New Input System. Timing-tolerant (4 s gap resets), ignores non-sequence keys.
- `ScoreManager.AddScore`: multiplies gained points by `EasterEggs.ScoreBonusMultiplier` (1f when off → zero overhead).
- `RabbitController.ApplyEasterEggVisuals`: clones the shared Rabbit_Mat once, tints it, and assigns it to every renderer that used the original. Tracked + destroyed in OnDestroy so there's no material leak.
- `MainMenuUI`: live indicator synced via `OnGoldenRabbitChanged`.

## Robustness
- Setter no-ops on identical writes; saves immediately so the choice survives hard exits.
- All cross-system reads are lazy / event-driven — no hard wiring.
- Toast uses unscaled time so it survives `Time.timeScale = 0` pause.

Budget: full PRO implementation, no shortcuts.