### PR TITLE
feat(input): production-grade mobile touch controls

### DIFF
--- a/Assets/_Project/Scripts/Core/InputManager.cs
+++ b/Assets/_Project/Scripts/Core/InputManager.cs
@@ -1,23 +1,60 @@
+using System;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace ReverseRabbitRunner.Core
 {
     /// <summary>
-    /// Handles cross-platform input mapping for lane switching.
-    /// Supports keyboard (A/D, arrows), touch swipe, and gamepad.
+    /// Cross-platform touch / swipe input. Emits high-level events
+    /// (<see cref="OnSwipeLeft"/>, <see cref="OnSwipeRight"/>,
+    /// <see cref="OnSwipeUp"/>, <see cref="OnTap"/>) so gameplay code
+    /// doesn't need to know about the underlying input device.
+    ///
+    /// Implementation notes:
+    /// - Uses Unity's new Input System exclusively (project is in Input
+    ///   System-only mode). Reads <see cref="Touchscreen.current"/> primary
+    ///   touch — sufficient for an endless runner; multi-touch isn't needed.
+    /// - Horizontal swipes fire <em>live</em> the moment the threshold is
+    ///   crossed while the finger is still down. This feels much snappier
+    ///   than waiting for touch-up. A per-touch latch prevents repeats.
+    /// - Vertical "swipe up" and tap are detected on touch release.
+    /// - Thresholds scale with screen DPI when available so a "swipe" is
+    ///   roughly the same physical distance on phones and tablets.
+    /// - Auto-spawned via <see cref="RuntimeInitializeOnLoadMethodAttribute"/>
+    ///   as a DontDestroyOnLoad singleton; works in every scene without
+    ///   relying on SceneSetup wiring.
     /// </summary>
     public class InputManager : MonoBehaviour
     {
         public static InputManager Instance { get; private set; }
 
-        [Header("Touch Settings")]
-        [SerializeField] private float swipeThreshold = 50f;
+        [Header("Swipe (in millimetres of travel)")]
+        [SerializeField] private float swipeThresholdMm = 8f;
+        [SerializeField] private float maxTapDurationSeconds = 0.25f;
+        [SerializeField] private float maxTapTravelMm = 4f;
 
+        // Fallback DPI when the device reports 0 (e.g. desktop).
+        private const float FallbackDpi = 160f;
+
+        public event Action OnSwipeLeft;
+        public event Action OnSwipeRight;
+        public event Action OnSwipeUp;
+        public event Action OnTap;
+
+        private bool touchActive;
         private Vector2 touchStartPos;
-        private bool isSwiping = false;
+        private float touchStartTime;
+        private bool horizontalLatched;
+        private bool verticalLatched;
 
-        public event System.Action OnSwipeLeft;
-        public event System.Action OnSwipeRight;
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (Instance != null) return;
+            var go = new GameObject("[InputManager]");
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<InputManager>();
+        }
 
         private void Awake()
         {
@@ -29,44 +66,89 @@ namespace ReverseRabbitRunner.Core
             Instance = this;
         }
 
-        private void Update()
+        private float PixelsPerMm
         {
-            HandleTouchInput();
+            get
+            {
+                float dpi = Screen.dpi > 0f ? Screen.dpi : FallbackDpi;
+                return dpi / 25.4f;
+            }
         }
 
-        private void HandleTouchInput()
+        private void Update()
         {
-            if (Input.touchCount > 0)
+            var ts = Touchscreen.current;
+            if (ts == null) return;
+
+            var primary = ts.primaryTouch;
+            bool isPressed = primary.press.isPressed;
+
+            if (isPressed && !touchActive)
             {
-                Touch touch = Input.GetTouch(0);
+                // Touch begin
+                touchActive = true;
+                touchStartPos = primary.position.ReadValue();
+                touchStartTime = Time.unscaledTime;
+                horizontalLatched = false;
+                verticalLatched = false;
+                return;
+            }
 
-                switch (touch.phase)
+            if (!isPressed)
+            {
+                if (touchActive)
                 {
-                    case TouchPhase.Began:
-                        touchStartPos = touch.position;
-                        isSwiping = true;
-                        break;
+                    // Touch end — possibly a tap or an upward swipe-on-release.
+                    Vector2 endPos = primary.position.ReadValue();
+                    Vector2 delta = endPos - touchStartPos;
+                    float duration = Time.unscaledTime - touchStartTime;
+                    float ppmm = PixelsPerMm;
 
-                    case TouchPhase.Ended:
-                        if (isSwiping)
+                    if (!horizontalLatched && !verticalLatched)
+                    {
+                        bool isTap =
+                            duration <= maxTapDurationSeconds &&
+                            delta.magnitude <= maxTapTravelMm * ppmm;
+
+                        if (isTap)
                         {
-                            Vector2 swipeDelta = touch.position - touchStartPos;
-                            if (Mathf.Abs(swipeDelta.x) > swipeThreshold)
-                            {
-                                if (swipeDelta.x < 0)
-                                    OnSwipeLeft?.Invoke();
-                                else
-                                    OnSwipeRight?.Invoke();
-                            }
-                            isSwiping = false;
+                            OnTap?.Invoke();
                         }
-                        break;
+                        else if (delta.y >= swipeThresholdMm * ppmm &&
+                                 delta.y >= Mathf.Abs(delta.x))
+                        {
+                            OnSwipeUp?.Invoke();
+                        }
+                    }
+                    touchActive = false;
+                }
+                return;
+            }
 
-                    case TouchPhase.Canceled:
-                        isSwiping = false;
-                        break;
+            // Live tracking — fire horizontal swipe as soon as threshold is crossed.
+            if (touchActive && !horizontalLatched)
+            {
+                Vector2 delta = primary.position.ReadValue() - touchStartPos;
+                float threshold = swipeThresholdMm * PixelsPerMm;
+
+                if (Mathf.Abs(delta.x) >= threshold && Mathf.Abs(delta.x) >= Mathf.Abs(delta.y))
+                {
+                    horizontalLatched = true;
+                    if (delta.x < 0f) OnSwipeLeft?.Invoke();
+                    else              OnSwipeRight?.Invoke();
+                }
+                else if (!verticalLatched && delta.y >= threshold && delta.y >= Mathf.Abs(delta.x))
+                {
+                    // Live up-swipe so jump triggers without waiting for finger lift.
+                    verticalLatched = true;
+                    OnSwipeUp?.Invoke();
                 }
             }
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this) Instance = null;
         }
     }
 }

--- a/Assets/_Project/Scripts/Player/RabbitController.cs
+++ b/Assets/_Project/Scripts/Player/RabbitController.cs
@@ -219,12 +219,57 @@ namespace ReverseRabbitRunner.Player
         {
             moveAction?.Enable();
             jumpAction?.Enable();
+            SubscribeTouchInput();
         }
 
         private void OnDisable()
         {
             moveAction?.Disable();
             jumpAction?.Disable();
+            UnsubscribeTouchInput();
+        }
+
+        private bool touchInputBound;
+
+        private void SubscribeTouchInput()
+        {
+            var im = Core.InputManager.Instance;
+            if (im == null || touchInputBound) return;
+            im.OnSwipeLeft  += HandleSwipeLeft;
+            im.OnSwipeRight += HandleSwipeRight;
+            im.OnSwipeUp    += HandleTouchJump;
+            im.OnTap        += HandleTouchJump;
+            touchInputBound = true;
+        }
+
+        private void UnsubscribeTouchInput()
+        {
+            var im = Core.InputManager.Instance;
+            if (im == null || !touchInputBound) return;
+            im.OnSwipeLeft  -= HandleSwipeLeft;
+            im.OnSwipeRight -= HandleSwipeRight;
+            im.OnSwipeUp    -= HandleTouchJump;
+            im.OnTap        -= HandleTouchJump;
+            touchInputBound = false;
+        }
+
+        private void HandleSwipeLeft()
+        {
+            if (!isAlive) return;
+            MoveLeft();
+        }
+
+        private void HandleSwipeRight()
+        {
+            if (!isAlive) return;
+            MoveRight();
+        }
+
+        private void HandleTouchJump()
+        {
+            if (!isAlive) return;
+            if (controller != null && controller.isGrounded && !isFlying)
+                Jump();
         }
 
         private void OnDestroy()
@@ -242,6 +287,10 @@ namespace ReverseRabbitRunner.Player
 
         private void Update()
         {
+            // Lazy subscribe — InputManager auto-spawns via RuntimeInitializeOnLoad,
+            // which may race with this controller's OnEnable on first scene load.
+            if (!touchInputBound) SubscribeTouchInput();
+
             if (!isAlive) return;
 
             // DEBUG: Shift+1 = instant death (farmer catches up and kills)
@@ -367,12 +416,6 @@ namespace ReverseRabbitRunner.Player
 
             if (jumpPressed && controller.isGrounded && !isFlying)
                 Jump();
-
-            // Touch swipe (using Touchscreen from Input System)
-            if (Touchscreen.current != null && Touchscreen.current.primaryTouch.press.wasPressedThisFrame)
-            {
-                // Store start position handled via pointer
-            }
         }
 
         private void Jump()

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -551,7 +551,7 @@ namespace ReverseRabbitRunner.UI
                     GUI.Label(new Rect(0, Screen.height * 0.40f, Screen.width, 60),
                         "PC: A/D or ←/→ = switch lanes | Space/W/↑ = jump | Numpad = mirrors | Esc/Q = pause", infoStyle);
                     GUI.Label(new Rect(0, Screen.height * 0.46f, Screen.width, 30),
-                        "Mobile: Swipe left/right to switch lanes", infoStyle);
+                        "Mobile: Swipe lanes • Swipe up or tap to jump", infoStyle);
 
                     GUI.Label(new Rect(0, Screen.height * 0.55f, Screen.width, 30), "Master Volume", infoStyle);
                     float vol = GUI.HorizontalSlider(


### PR DESCRIPTION
## Why
The old `InputManager` used legacy `Input.GetTouch` — broken in this project (Input System-only mode) — and only emitted swipe-left/right events that nothing subscribed to. The touch handler in `RabbitController` was an empty stub. Mobile play was effectively unsupported.

## InputManager (rewrite)
- New Input System (`Touchscreen.current`).
- Emits `OnSwipeLeft / OnSwipeRight / OnSwipeUp / OnTap`.
- Horizontal swipes fire **live** the moment the threshold is crossed (per-touch latch prevents repeats). Vertical swipe-up too.
- Tap = short duration + small travel, detected on release.
- Thresholds in millimetres, converted via `Screen.dpi` for consistency across phones/tablets/desktops (160 DPI fallback when unreported).
- Auto-spawned via `RuntimeInitializeOnLoadMethod` as a DontDestroyOnLoad singleton — no SceneSetup dependency.

## RabbitController
- Subscribes to all four events; lane-change for swipe L/R, jump for swipe-up or tap (gated by `isGrounded && !isFlying`, same as keyboard).
- Lazy retry in Update covers the OnEnable-vs-RuntimeInitialize race.
- Removed the empty stub at the old line 371.

## GameHUD
Pause-panel mobile hint updated to `Swipe lanes • Swipe up or tap to jump`.