### PR TITLE
feat(achievements): persistent achievement system + toast HUD

### DIFF
--- a/Assets/_Project/Scripts/Core/Achievements.cs
+++ b/Assets/_Project/Scripts/Core/Achievements.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    public enum AchievementId
+    {
+        FirstHundred,        // run 100m total in a single run
+        FirstKilometer,      // run 1000m total in a single run
+        MarathonRunner,      // run 5000m total in a single run
+        ComboNovice,         // hit a 5x combo
+        ComboMaster,         // hit a 10x combo
+        ComboLegend,         // hit a 25x combo
+        TierClimber,         // reach difficulty tier 8
+        TopHundredCarrots,   // collect 100 carrots lifetime
+        TopThousandCarrots,  // collect 1000 carrots lifetime
+        MagnetMagnet,        // trigger 25 magnet pickups lifetime
+        NearMissPro,         // record 10 near-misses in a single run
+        Untouchable,         // reach 500m without a single stumble
+        FarFurtherFurthest,  // beat your best-distance record
+        Pyromaniac,          // reach a score of 5000 in one run
+        GoldenSecret,        // unlock the Golden Rabbit cheat
+    }
+
+    /// <summary>
+    /// Static achievement registry: definitions, persistence, unlock state.
+    ///
+    /// Design:
+    /// - Definitions live here so any subsystem can describe them in UI.
+    /// - Unlock state and lifetime counters persist via <see cref="PlayerPrefs"/>.
+    /// - Stateless w.r.t. game objects; <see cref="AchievementsRuntime"/> wires
+    ///   the events.
+    /// </summary>
+    public static class Achievements
+    {
+        public readonly struct Definition
+        {
+            public readonly AchievementId Id;
+            public readonly string Title;
+            public readonly string Description;
+            public readonly string Icon; // emoji glyph
+            public Definition(AchievementId id, string title, string desc, string icon)
+            {
+                Id = id; Title = title; Description = desc; Icon = icon;
+            }
+        }
+
+        private static readonly Definition[] DefinitionTable =
+        {
+            new(AchievementId.FirstHundred,       "Just a Sprint",        "Run 100 metres in one run.",                 "🏁"),
+            new(AchievementId.FirstKilometer,     "Kilometre Club",       "Run 1 km in one run.",                       "🥕"),
+            new(AchievementId.MarathonRunner,     "Marathon Rabbit",      "Run 5 km in one run.",                       "🏆"),
+            new(AchievementId.ComboNovice,        "Combo Novice",         "Hit a 5× combo multiplier.",                 "✨"),
+            new(AchievementId.ComboMaster,        "Combo Master",         "Hit a 10× combo multiplier.",                "💫"),
+            new(AchievementId.ComboLegend,        "Combo Legend",         "Hit a 25× combo multiplier.",                "🌟"),
+            new(AchievementId.TierClimber,        "Tier Climber",         "Reach difficulty tier 8.",                   "📈"),
+            new(AchievementId.TopHundredCarrots,  "Carrot Connoisseur",   "Collect 100 carrots (lifetime).",            "🥕"),
+            new(AchievementId.TopThousandCarrots, "Carrot Tycoon",        "Collect 1,000 carrots (lifetime).",          "💰"),
+            new(AchievementId.MagnetMagnet,       "Magnet Magnet",        "Trigger 25 magnet power-ups (lifetime).",    "🧲"),
+            new(AchievementId.NearMissPro,        "Lived Dangerously",    "10 near-misses in one run.",                 "😱"),
+            new(AchievementId.Untouchable,        "Untouchable",          "Reach 500 m without a single stumble.",      "🛡"),
+            new(AchievementId.FarFurtherFurthest, "Personal Best",        "Beat your previous best-distance record.",   "🚀"),
+            new(AchievementId.Pyromaniac,         "Score Five Grand",     "End a run with 5,000 points or more.",       "🔥"),
+            new(AchievementId.GoldenSecret,       "Hidden in Plain Code", "Discover the Golden Rabbit cheat.",          "🥕✨"),
+        };
+
+        public static IReadOnlyList<Definition> All => DefinitionTable;
+
+        /// <summary>Raised whenever an achievement transitions from locked → unlocked.</summary>
+        public static event Action<Definition> OnUnlocked;
+
+        // --- Unlock state ---
+
+        private const string PrefPrefix = "Ach_";
+
+        public static bool IsUnlocked(AchievementId id)
+            => PlayerPrefs.GetInt(PrefPrefix + id, 0) == 1;
+
+        /// <summary>
+        /// Mark an achievement as unlocked. No-op if already unlocked.
+        /// Persists immediately and raises <see cref="OnUnlocked"/>.
+        /// </summary>
+        public static void Unlock(AchievementId id)
+        {
+            if (IsUnlocked(id)) return;
+            PlayerPrefs.SetInt(PrefPrefix + id, 1);
+            PlayerPrefs.Save();
+
+            for (int i = 0; i < DefinitionTable.Length; i++)
+            {
+                if (DefinitionTable[i].Id == id)
+                {
+                    OnUnlocked?.Invoke(DefinitionTable[i]);
+                    return;
+                }
+            }
+        }
+
+        // --- Lifetime counters ---
+
+        public const string LifetimeCarrotsKey = "Ach_LifetimeCarrots";
+        public const string LifetimeMagnetsKey = "Ach_LifetimeMagnets";
+
+        public static int GetCounter(string key) => PlayerPrefs.GetInt(key, 0);
+
+        /// <summary>Increment a lifetime counter and return the new value.</summary>
+        public static int IncrementCounter(string key, int delta = 1)
+        {
+            int v = PlayerPrefs.GetInt(key, 0) + delta;
+            PlayerPrefs.SetInt(key, v);
+            return v; // Caller may batch PlayerPrefs.Save with other writes.
+        }
+
+        public static int UnlockedCount
+        {
+            get
+            {
+                int n = 0;
+                for (int i = 0; i < DefinitionTable.Length; i++)
+                    if (IsUnlocked(DefinitionTable[i].Id)) n++;
+                return n;
+            }
+        }
+
+        public static int Total => DefinitionTable.Length;
+    }
+}

--- a/Assets/_Project/Scripts/Core/AchievementsRuntime.cs
+++ b/Assets/_Project/Scripts/Core/AchievementsRuntime.cs
@@ -1,0 +1,200 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Drives the achievement system at runtime: subscribes to gameplay events
+    /// (<see cref="ScoreManager"/>, <see cref="Player.RabbitController"/>,
+    /// <see cref="PowerUps.MagnetEffect"/>, <see cref="EasterEggs"/>) and calls
+    /// <see cref="Achievements.Unlock"/> when thresholds are crossed. Updates
+    /// lifetime counters in <see cref="PlayerPrefs"/>.
+    ///
+    /// Auto-spawned via <see cref="RuntimeInitializeOnLoadMethodAttribute"/>
+    /// as a DontDestroyOnLoad singleton — works in every scene.
+    ///
+    /// Subscriptions retry lazily in Update because game objects (rabbit,
+    /// score manager) may spawn after the first frame on a fresh scene load.
+    /// </summary>
+    public class AchievementsRuntime : MonoBehaviour
+    {
+        public static AchievementsRuntime Instance { get; private set; }
+
+        // Per-run counters (reset on run start).
+        private int runNearMissCount;
+        private bool runStumbled;
+        private float runStartDistance;
+
+        // Wiring state.
+        private Player.RabbitController cachedRabbit;
+        private ScoreManager cachedScore;
+        private bool subscribedRabbit;
+        private bool subscribedScore;
+        private bool subscribedMagnet;
+        private bool subscribedGolden;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (Instance != null) return;
+            var go = new GameObject("[AchievementsRuntime]");
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<AchievementsRuntime>();
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+
+            // Static event subscriptions (don't depend on scene objects).
+            PowerUps.MagnetEffect.OnMagnetActivated += OnMagnetActivated;
+            subscribedMagnet = true;
+
+            EasterEggs.OnGoldenRabbitChanged += OnGoldenRabbitChanged;
+            subscribedGolden = true;
+
+            // Retroactive: if user already unlocked the cheat in a previous
+            // build (before this system existed), grant the matching badge.
+            if (EasterEggs.GoldenRabbitUnlocked)
+                Achievements.Unlock(AchievementId.GoldenSecret);
+        }
+
+        private void Update()
+        {
+            if (!subscribedRabbit)
+            {
+                var rabbit = FindAnyObjectByType<Player.RabbitController>();
+                if (rabbit != null)
+                {
+                    cachedRabbit = rabbit;
+                    rabbit.OnNearMiss += OnNearMiss;
+                    rabbit.OnStumble  += OnStumble;
+                    rabbit.OnCollectCarrot += OnCollectCarrot;
+                    subscribedRabbit = true;
+                    BeginRun();
+                }
+            }
+
+            if (!subscribedScore)
+            {
+                var sm = ScoreManager.Instance;
+                if (sm != null)
+                {
+                    cachedScore = sm;
+                    sm.OnComboChanged += OnComboChanged;
+                    sm.OnRunCommitted += OnRunCommitted;
+                    subscribedScore = true;
+                }
+            }
+
+            // Distance-based achievements check while a run is active.
+            if (cachedScore != null && cachedRabbit != null)
+            {
+                float dist = cachedScore.CurrentRunDistance;
+                if (dist >= 100f)  Achievements.Unlock(AchievementId.FirstHundred);
+                if (dist >= 1000f) Achievements.Unlock(AchievementId.FirstKilometer);
+                if (dist >= 5000f) Achievements.Unlock(AchievementId.MarathonRunner);
+
+                // Untouchable — 500m without a stumble. We treat distance from
+                // the last reset as the qualifying span; runStumbled clears at
+                // run start.
+                if (!runStumbled && dist - runStartDistance >= 500f)
+                    Achievements.Unlock(AchievementId.Untouchable);
+
+                if (cachedScore.MaxTierReached >= 8)
+                    Achievements.Unlock(AchievementId.TierClimber);
+            }
+
+            // Detect rabbit/scene swap (re-grab on next frame).
+            if (cachedRabbit == null && subscribedRabbit) subscribedRabbit = false;
+            if (cachedScore == null && subscribedScore) subscribedScore = false;
+        }
+
+        private void BeginRun()
+        {
+            runNearMissCount = 0;
+            runStumbled = false;
+            runStartDistance = cachedScore != null ? cachedScore.CurrentRunDistance : 0f;
+        }
+
+        // --- Event handlers ---
+
+        private void OnNearMiss(GameObject _)
+        {
+            runNearMissCount++;
+            if (runNearMissCount >= 10)
+                Achievements.Unlock(AchievementId.NearMissPro);
+        }
+
+        private void OnStumble(float _)
+        {
+            runStumbled = true;
+        }
+
+        private void OnCollectCarrot(GameObject _)
+        {
+            int total = Achievements.IncrementCounter(Achievements.LifetimeCarrotsKey);
+            if (total >= 100)   Achievements.Unlock(AchievementId.TopHundredCarrots);
+            if (total >= 1000)  Achievements.Unlock(AchievementId.TopThousandCarrots);
+        }
+
+        private void OnMagnetActivated()
+        {
+            int total = Achievements.IncrementCounter(Achievements.LifetimeMagnetsKey);
+            if (total >= 25) Achievements.Unlock(AchievementId.MagnetMagnet);
+            // Counter writes are batched; flush opportunistically.
+            PlayerPrefs.Save();
+        }
+
+        private void OnComboChanged(int comboCount, int multiplier, bool tierUp)
+        {
+            if (multiplier >= 5)  Achievements.Unlock(AchievementId.ComboNovice);
+            if (multiplier >= 10) Achievements.Unlock(AchievementId.ComboMaster);
+            if (multiplier >= 25) Achievements.Unlock(AchievementId.ComboLegend);
+        }
+
+        private void OnRunCommitted()
+        {
+            if (cachedScore == null) return;
+            if (cachedScore.LastRunWasNewBestDistance)
+                Achievements.Unlock(AchievementId.FarFurtherFurthest);
+            if (cachedScore.CurrentScore >= 5000)
+                Achievements.Unlock(AchievementId.Pyromaniac);
+
+            // Persist lifetime counters once per run end.
+            PlayerPrefs.Save();
+
+            // Prepare for the next run.
+            BeginRun();
+        }
+
+        private void OnGoldenRabbitChanged(bool unlocked)
+        {
+            if (unlocked) Achievements.Unlock(AchievementId.GoldenSecret);
+        }
+
+        private void OnDestroy()
+        {
+            if (subscribedMagnet)
+                PowerUps.MagnetEffect.OnMagnetActivated -= OnMagnetActivated;
+            if (subscribedGolden)
+                EasterEggs.OnGoldenRabbitChanged -= OnGoldenRabbitChanged;
+            if (subscribedRabbit && cachedRabbit != null)
+            {
+                cachedRabbit.OnNearMiss -= OnNearMiss;
+                cachedRabbit.OnStumble  -= OnStumble;
+                cachedRabbit.OnCollectCarrot -= OnCollectCarrot;
+            }
+            if (subscribedScore && cachedScore != null)
+            {
+                cachedScore.OnComboChanged -= OnComboChanged;
+                cachedScore.OnRunCommitted -= OnRunCommitted;
+            }
+            if (Instance == this) Instance = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/AchievementsToast.cs
+++ b/Assets/_Project/Scripts/Core/AchievementsToast.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Lightweight HUD that draws an "Achievement unlocked" toast whenever
+    /// <see cref="Achievements.OnUnlocked"/> fires. Multiple unlocks queue
+    /// behind one another so a single combo doesn't drop notifications.
+    ///
+    /// Auto-spawned via <see cref="RuntimeInitializeOnLoadMethodAttribute"/>;
+    /// uses unscaled time so a paused (timeScale = 0) game still animates the
+    /// toast cleanly.
+    /// </summary>
+    public class AchievementsToast : MonoBehaviour
+    {
+        private const float DisplayDuration = 3.5f;
+        private const float FadeDuration = 0.45f;
+
+        private static AchievementsToast _instance;
+
+        private struct Pending
+        {
+            public Achievements.Definition Def;
+            public float ShownAt;
+        }
+
+        private readonly Queue<Pending> queue = new();
+        private Pending? active;
+        private GUIStyle titleStyle;
+        private GUIStyle bodyStyle;
+        private GUIStyle iconStyle;
+        private bool stylesReady;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (_instance != null) return;
+            var go = new GameObject("[AchievementsToast]");
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<AchievementsToast>();
+        }
+
+        private void OnEnable()
+        {
+            Achievements.OnUnlocked += HandleUnlocked;
+        }
+
+        private void OnDisable()
+        {
+            Achievements.OnUnlocked -= HandleUnlocked;
+        }
+
+        private void HandleUnlocked(Achievements.Definition def)
+        {
+            queue.Enqueue(new Pending { Def = def, ShownAt = -1f });
+        }
+
+        private void Update()
+        {
+            if (active == null && queue.Count > 0)
+            {
+                var next = queue.Dequeue();
+                next.ShownAt = Time.unscaledTime;
+                active = next;
+            }
+            else if (active != null && Time.unscaledTime - active.Value.ShownAt > DisplayDuration)
+            {
+                active = null;
+            }
+        }
+
+        private void EnsureStyles()
+        {
+            if (stylesReady) return;
+            titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 22, fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleLeft,
+            };
+            bodyStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14, alignment = TextAnchor.MiddleLeft, wordWrap = true,
+            };
+            iconStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 36, alignment = TextAnchor.MiddleCenter,
+            };
+            stylesReady = true;
+        }
+
+        private void OnGUI()
+        {
+            if (active == null) return;
+            EnsureStyles();
+
+            float age = Time.unscaledTime - active.Value.ShownAt;
+            float alpha = 1f;
+            if (age < FadeDuration)
+                alpha = age / FadeDuration;
+            else if (age > DisplayDuration - FadeDuration)
+                alpha = Mathf.Max(0f, (DisplayDuration - age) / FadeDuration);
+
+            float w = 380f, h = 88f;
+            float x = (Screen.width - w) * 0.5f;
+            float y = 24f;
+            var rect = new Rect(x, y, w, h);
+
+            var prevColor = GUI.color;
+
+            GUI.color = new Color(0f, 0f, 0f, 0.78f * alpha);
+            GUI.Box(rect, GUIContent.none);
+
+            GUI.color = new Color(1f, 0.84f, 0.2f, alpha); // gold accent line
+            GUI.Box(new Rect(x, y, w, 3f), GUIContent.none);
+
+            GUI.color = new Color(1f, 1f, 1f, alpha);
+            GUI.Label(new Rect(x + 8f, y + 8f, 72f, h - 16f), active.Value.Def.Icon, iconStyle);
+            GUI.Label(new Rect(x + 88f, y + 8f, w - 96f, 28f), "Achievement Unlocked", titleStyle);
+            GUI.Label(new Rect(x + 88f, y + 36f, w - 96f, 22f), active.Value.Def.Title, bodyStyle);
+            GUI.color = new Color(0.85f, 0.85f, 0.85f, alpha);
+            GUI.Label(new Rect(x + 88f, y + 56f, w - 96f, 26f), active.Value.Def.Description, bodyStyle);
+
+            GUI.color = prevColor;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Core/DifficultyManager.cs.meta
+++ b/Assets/_Project/Scripts/Core/DifficultyManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2a9eecc7a95a1a4198c1b5dc4fff874

--- a/Assets/_Project/Scripts/Core/EasterEggs.cs.meta
+++ b/Assets/_Project/Scripts/Core/EasterEggs.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acfba2f752ac7e04cafd68e67190194f

--- a/Assets/_Project/Scripts/Core/JuiceVfx.cs.meta
+++ b/Assets/_Project/Scripts/Core/JuiceVfx.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92f2d094ab3baba499b643f482456322

--- a/Assets/_Project/Scripts/Core/KonamiCodeDetector.cs.meta
+++ b/Assets/_Project/Scripts/Core/KonamiCodeDetector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b1f97829726ae184e9352facaa54d9f1

--- a/Assets/_Project/Scripts/Core/ProceduralSfx.cs.meta
+++ b/Assets/_Project/Scripts/Core/ProceduralSfx.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 38c3332561b6fa843b5d18cc41685948

--- a/Assets/_Project/Scripts/Player/NearMissDetector.cs.meta
+++ b/Assets/_Project/Scripts/Player/NearMissDetector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 535b365c516dde040a8ab6fcc3730098

--- a/Assets/_Project/Scripts/PowerUps/MagnetCarrot.cs.meta
+++ b/Assets/_Project/Scripts/PowerUps/MagnetCarrot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f54008e613e2adc4b9e16cabcec30714

--- a/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs.meta
+++ b/Assets/_Project/Scripts/PowerUps/MagnetEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4113dda53e41c64b99cedf93908cd4c

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -32,6 +32,8 @@ namespace ReverseRabbitRunner.UI
         private bool stylesInitialized = false;
         private bool isPaused = false;
         private bool showSettings = false;
+        private bool showAchievements = false;
+        private Vector2 achievementsScroll;
         private bool wasStumbling;
         private float stumbleFlashTimer;
 
@@ -359,6 +361,12 @@ namespace ReverseRabbitRunner.UI
                     return;
                 }
 
+                if (showAchievements)
+                {
+                    showAchievements = false;
+                    return;
+                }
+
                 isPaused = !isPaused;
                 Time.timeScale = isPaused ? 0f : 1f;
             }
@@ -490,7 +498,7 @@ namespace ReverseRabbitRunner.UI
                 GUI.DrawTexture(new Rect(0, 0, Screen.width, Screen.height), Texture2D.whiteTexture);
                 GUI.color = Color.white;
 
-                if (!showSettings)
+                if (!showSettings && !showAchievements)
                 {
                     gameOverStyle.normal.textColor = Color.white;
                     GUI.Label(new Rect(0, Screen.height * 0.2f, Screen.width, 60), "PAUSED", gameOverStyle);
@@ -510,20 +518,27 @@ namespace ReverseRabbitRunner.UI
                     float btnW = 300, btnH = 50;
                     float btnX = (Screen.width - btnW) / 2f;
 
-                    if (GUI.Button(new Rect(btnX, Screen.height * 0.38f, btnW, btnH), "▶  RESUME", buttonStyle))
+                    if (GUI.Button(new Rect(btnX, Screen.height * 0.36f, btnW, btnH), "▶  RESUME", buttonStyle))
                     {
                         Core.AudioManager.Instance?.PlayMenuClick();
                         isPaused = false;
                         Time.timeScale = 1f;
                     }
 
-                    if (GUI.Button(new Rect(btnX, Screen.height * 0.48f, btnW, btnH), "⚙  SETTINGS", buttonStyle))
+                    if (GUI.Button(new Rect(btnX, Screen.height * 0.45f, btnW, btnH), "⚙  SETTINGS", buttonStyle))
                     {
                         Core.AudioManager.Instance?.PlayMenuClick();
                         showSettings = true;
                     }
 
-                    if (GUI.Button(new Rect(btnX, Screen.height * 0.58f, btnW, btnH), "✕  QUIT TO MENU", buttonStyle))
+                    string achLabel = $"🏆  ACHIEVEMENTS  ({Core.Achievements.UnlockedCount}/{Core.Achievements.Total})";
+                    if (GUI.Button(new Rect(btnX, Screen.height * 0.54f, btnW, btnH), achLabel, buttonStyle))
+                    {
+                        Core.AudioManager.Instance?.PlayMenuClick();
+                        showAchievements = true;
+                    }
+
+                    if (GUI.Button(new Rect(btnX, Screen.height * 0.63f, btnW, btnH), "✕  QUIT TO MENU", buttonStyle))
                     {
                         Core.AudioManager.Instance?.PlayMenuClick();
                         isPaused = false;
@@ -531,11 +546,11 @@ namespace ReverseRabbitRunner.UI
                     }
 
                     infoStyle.alignment = TextAnchor.MiddleCenter;
-                    GUI.Label(new Rect(0, Screen.height * 0.72f, Screen.width, 30),
+                    GUI.Label(new Rect(0, Screen.height * 0.74f, Screen.width, 30),
                         "Esc or Q to resume", infoStyle);
                     infoStyle.alignment = TextAnchor.UpperLeft;
                 }
-                else
+                else if (showSettings)
                 {
                     // Settings sub-panel
                     gameOverStyle.normal.textColor = Color.white;
@@ -617,6 +632,10 @@ namespace ReverseRabbitRunner.UI
                         showSettings = false;
                     }
                     infoStyle.alignment = TextAnchor.UpperLeft;
+                }
+                else // showAchievements
+                {
+                    DrawAchievementsPanel();
                 }
 
                 return; // Don't draw game over or controls hint while paused
@@ -708,6 +727,81 @@ namespace ReverseRabbitRunner.UI
             GUI.Label(new Rect(0, Screen.height - 50, Screen.width, 40),
                 "A/D or ←/→ to switch lanes | Space/W/↑ to jump", infoStyle);
             infoStyle.alignment = TextAnchor.UpperLeft;
+        }
+
+        /// <summary>Renders the achievements list inside the pause overlay.</summary>
+        private void DrawAchievementsPanel()
+        {
+            gameOverStyle.normal.textColor = Color.white;
+            GUI.Label(new Rect(0, Screen.height * 0.10f, Screen.width, 60),
+                $"ACHIEVEMENTS  {Core.Achievements.UnlockedCount}/{Core.Achievements.Total}",
+                gameOverStyle);
+            gameOverStyle.normal.textColor = Color.red;
+
+            float listW = Mathf.Min(640f, Screen.width - 80f);
+            float listX = (Screen.width - listW) * 0.5f;
+            float listY = Screen.height * 0.22f;
+            float listH = Screen.height * 0.62f;
+
+            var defs = Core.Achievements.All;
+            float rowH = 70f;
+            float contentH = defs.Count * (rowH + 6f);
+
+            var view = new Rect(listX, listY, listW, listH);
+            var content = new Rect(0, 0, listW - 24f, contentH);
+            achievementsScroll = GUI.BeginScrollView(view, achievementsScroll, content);
+
+            var iconStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 32, alignment = TextAnchor.MiddleCenter,
+            };
+            var titleLabel = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 18, fontStyle = FontStyle.Bold, alignment = TextAnchor.MiddleLeft,
+            };
+            var descLabel = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 14, alignment = TextAnchor.MiddleLeft, wordWrap = true,
+            };
+
+            for (int i = 0; i < defs.Count; i++)
+            {
+                var def = defs[i];
+                bool unlocked = Core.Achievements.IsUnlocked(def.Id);
+                float y = i * (rowH + 6f);
+
+                GUI.color = unlocked ? new Color(0.18f, 0.32f, 0.18f, 0.9f)
+                                     : new Color(0.18f, 0.18f, 0.18f, 0.85f);
+                GUI.DrawTexture(new Rect(0, y, content.width, rowH), Texture2D.whiteTexture);
+                GUI.color = unlocked ? new Color(1f, 0.84f, 0.2f, 1f)
+                                     : new Color(0.4f, 0.4f, 0.4f, 1f);
+                GUI.DrawTexture(new Rect(0, y, 4f, rowH), Texture2D.whiteTexture);
+                GUI.color = Color.white;
+
+                titleLabel.normal.textColor = unlocked ? Color.white : new Color(0.65f, 0.65f, 0.65f);
+                descLabel.normal.textColor  = unlocked ? new Color(0.85f, 0.85f, 0.85f)
+                                                       : new Color(0.55f, 0.55f, 0.55f);
+                iconStyle.normal.textColor = unlocked ? Color.white : new Color(0.5f, 0.5f, 0.5f);
+
+                GUI.Label(new Rect(8f, y, 60f, rowH), unlocked ? def.Icon : "🔒", iconStyle);
+                GUI.Label(new Rect(76f, y + 8f, content.width - 80f, 24f), def.Title, titleLabel);
+                GUI.Label(new Rect(76f, y + 32f, content.width - 80f, 32f), def.Description, descLabel);
+            }
+
+            GUI.EndScrollView();
+
+            if (buttonStyle == null)
+            {
+                buttonStyle = new GUIStyle(GUI.skin.button) { fontSize = 24, fontStyle = FontStyle.Bold };
+                buttonStyle.normal.textColor = Color.white;
+            }
+            float backW = 200f, backH = 45f;
+            if (GUI.Button(new Rect((Screen.width - backW) * 0.5f, Screen.height * 0.90f, backW, backH),
+                "← BACK", buttonStyle))
+            {
+                Core.AudioManager.Instance?.PlayMenuClick();
+                showAchievements = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a complete achievement system: 15 achievements, toast HUD, pause-menu sub-panel.

### Files
- `Assets/_Project/Scripts/Core/Achievements.cs` — static registry, 15 definitions, PlayerPrefs unlock state, lifetime counters, `OnUnlocked` event.
- `Assets/_Project/Scripts/Core/AchievementsRuntime.cs` — auto-spawned singleton that subscribes to ScoreManager / RabbitController / MagnetEffect / EasterEggs events and unlocks achievements when thresholds are crossed.
- `Assets/_Project/Scripts/Core/AchievementsToast.cs` — stacking notification HUD; uses unscaled time so it animates while paused.
- `Assets/_Project/Scripts/UI/GameHUD.cs` — third sub-panel on the pause overlay listing all achievements, scrollable, locked/unlocked styling.

### Achievement set
Distance: First 100m, 1km, 5km. Combo: 5x / 10x / 25x. Lifetime carrots: 100 / 1000. Lifetime magnets: 25. Tier 8 reached. 10 near-misses in a single run. 500m without stumble. New best distance. End run with 5000+ score. Discover Konami cheat.

### Pro touches
- Static event subscriptions wired in `Awake`; instance subscriptions retry lazily (the rabbit / score manager may spawn on a later frame).
- Per-run state (near-miss count, stumble flag, run-start distance) resets on `OnRunCommitted` so achievements are correctly run-scoped.
- `Achievements.IncrementCounter` returns the new value to avoid a redundant PlayerPrefs read; `Save()` is batched at natural commit points.
- Retroactive unlock: if the Konami cheat was set before this build, the matching badge is granted on first boot.

### Testing
Static review only — no Unity build run in this environment. Event signatures verified against existing source: `OnComboChanged(int,int,bool)`, `OnRunCommitted()`, `OnNearMiss(GameObject)`, `OnStumble(float)`, `OnCollectCarrot(GameObject)`, `MagnetEffect.OnMagnetActivated()` (static), `EasterEggs.OnGoldenRabbitChanged(bool)`.