### PR TITLE
feat(daily-run): deterministic seed-of-the-day mode

### DIFF
--- a/Assets/_Project/Scripts/Core/DailyRun.cs
+++ b/Assets/_Project/Scripts/Core/DailyRun.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Daily-seeded run mode. Each calendar day (UTC) maps to a deterministic
+    /// seed; players opting into Daily Mode see the same chunk layout, the
+    /// same pickup placement, and the same per-day best score.
+    ///
+    /// State:
+    /// - <see cref="IsActive"/> is a session-only toggle; resetting on quit
+    ///   is intentional so the menu always defaults to a normal infinite run.
+    /// - <see cref="TodaySeed"/> derives from the current UTC date — stable
+    ///   for 24 hours.
+    /// - The per-day best score lives in <see cref="PlayerPrefs"/> under a
+    ///   date-keyed slot, so today's best is queryable in the UI.
+    /// </summary>
+    public static class DailyRun
+    {
+        public static bool IsActive { get; private set; }
+
+        /// <summary>Stable seed for the current UTC date.</summary>
+        public static int TodaySeed => DateSeed(DateTime.UtcNow);
+
+        /// <summary>Human-readable label, e.g. "2024-04-26".</summary>
+        public static string TodayLabel => DateTime.UtcNow.ToString("yyyy-MM-dd");
+
+        public static event Action<bool> OnActiveChanged;
+
+        public static void SetActive(bool active)
+        {
+            if (IsActive == active) return;
+            IsActive = active;
+            OnActiveChanged?.Invoke(active);
+        }
+
+        /// <summary>Best score recorded for today's seed.</summary>
+        public static int TodayBestScore
+        {
+            get => PlayerPrefs.GetInt(BestScoreKey(TodayLabel), 0);
+        }
+
+        /// <summary>
+        /// Submit a final score for today's seed. Updates per-day best when
+        /// it exceeds the previous record. Returns true when a new record
+        /// was set.
+        /// </summary>
+        public static bool SubmitScore(int score)
+        {
+            string key = BestScoreKey(TodayLabel);
+            int current = PlayerPrefs.GetInt(key, 0);
+            if (score > current)
+            {
+                PlayerPrefs.SetInt(key, score);
+                PlayerPrefs.Save();
+                return true;
+            }
+            return false;
+        }
+
+        // FNV-1a over the date string keeps the seed stable across reboots
+        // and platforms — DateTime.GetHashCode() is randomised in modern
+        // .NET builds, which would defeat the "shared seed for all players
+        // today" goal.
+        public static int DateSeed(DateTime utc)
+        {
+            string s = utc.ToString("yyyyMMdd");
+            unchecked
+            {
+                uint hash = 2166136261u;
+                for (int i = 0; i < s.Length; i++)
+                {
+                    hash ^= s[i];
+                    hash *= 16777619u;
+                }
+                return (int)(hash & 0x7fffffff);
+            }
+        }
+
+        private static string BestScoreKey(string dateLabel) => "DailyBest_" + dateLabel;
+    }
+}

--- a/Assets/_Project/Scripts/Core/GameManager.cs
+++ b/Assets/_Project/Scripts/Core/GameManager.cs
@@ -78,6 +78,9 @@ namespace ReverseRabbitRunner.Core
         public void GameOver()
         {
             ScoreManager.Instance?.CommitRunResults();
+            // Submit to daily-run leaderboard (per-day best) when applicable.
+            if (DailyRun.IsActive && ScoreManager.Instance != null)
+                DailyRun.SubmitScore(ScoreManager.Instance.CurrentScore);
             Time.timeScale = 0f;
             SetState(GameState.GameOver);
         }

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -478,6 +478,22 @@ namespace ReverseRabbitRunner.UI
                 GUI.Label(new Rect(padding, padding + 95, 300, 30), highText, infoStyle);
             }
 
+            // Daily Run ribbon — top centre, visible the whole run.
+            if (Core.DailyRun.IsActive)
+            {
+                int dailyBest = Core.DailyRun.TodayBestScore;
+                string ribbon = dailyBest > 0
+                    ? $"📅 DAILY  {Core.DailyRun.TodayLabel}  •  seed #{Core.DailyRun.TodaySeed:X8}  •  today's best: {dailyBest}"
+                    : $"📅 DAILY  {Core.DailyRun.TodayLabel}  •  seed #{Core.DailyRun.TodaySeed:X8}  •  set the bar!";
+                var prevAlign = infoStyle.alignment;
+                var prevColor = infoStyle.normal.textColor;
+                infoStyle.alignment = TextAnchor.UpperCenter;
+                infoStyle.normal.textColor = new Color(1f, 0.86f, 0.35f);
+                GUI.Label(new Rect(0, 6f, Screen.width, 22f), ribbon, infoStyle);
+                infoStyle.alignment = prevAlign;
+                infoStyle.normal.textColor = prevColor;
+            }
+
             // Chunk/Distance debug stats (bottom-left)
             var chunkMgr = GetChunkMgr();
             if (chunkMgr != null)

--- a/Assets/_Project/Scripts/UI/MainMenuUI.cs
+++ b/Assets/_Project/Scripts/UI/MainMenuUI.cs
@@ -79,13 +79,24 @@ namespace ReverseRabbitRunner.UI
             goldenIndicator.gameObject.SetActive(Core.EasterEggs.GoldenRabbitUnlocked);
 
             // Buttons
-            CreateButton(canvasObj.transform, "PlayButton", "▶  PLAY", new Vector2(0, 0), OnPlay,
+            CreateButton(canvasObj.transform, "PlayButton", "▶  PLAY", new Vector2(0, 25), OnPlay,
                 new Color(0.2f, 0.7f, 0.2f), Color.white, 36);
 
-            CreateButton(canvasObj.transform, "SettingsButton", "⚙  SETTINGS", new Vector2(0, -80), OnSettings,
+            string dailyLabel = $"📅  DAILY RUN  ({Core.DailyRun.TodayLabel})";
+            CreateButton(canvasObj.transform, "DailyButton", dailyLabel, new Vector2(0, -55), OnDailyRun,
+                new Color(0.55f, 0.45f, 0.18f), Color.white, 24);
+
+            int dailyBest = Core.DailyRun.TodayBestScore;
+            string bestLabel = dailyBest > 0
+                ? $"Today's seed #{Core.DailyRun.TodaySeed:X8} — best {dailyBest}"
+                : $"Today's seed #{Core.DailyRun.TodaySeed:X8} — beat it!";
+            CreateText(canvasObj.transform, "DailyBest", bestLabel,
+                new Vector2(0, -100), 14, new Color(0.85f, 0.78f, 0.5f));
+
+            CreateButton(canvasObj.transform, "SettingsButton", "⚙  SETTINGS", new Vector2(0, -150), OnSettings,
                 new Color(0.3f, 0.3f, 0.4f), Color.white, 28);
 
-            CreateButton(canvasObj.transform, "QuitButton", "✕  QUIT", new Vector2(0, -155), OnQuit,
+            CreateButton(canvasObj.transform, "QuitButton", "✕  QUIT", new Vector2(0, -225), OnQuit,
                 new Color(0.5f, 0.15f, 0.15f), Color.white, 28);
 
             // Version text
@@ -225,7 +236,16 @@ namespace ReverseRabbitRunner.UI
 
         private void OnPlay()
         {
-            // Persist any uncommitted slider changes before scene swap.
+            // Standard infinite run — make sure daily mode isn't lingering on
+            // from a previous press of the Daily Run button.
+            Core.DailyRun.SetActive(false);
+            PlayerPrefs.Save();
+            SceneManager.LoadScene("SampleScene");
+        }
+
+        private void OnDailyRun()
+        {
+            Core.DailyRun.SetActive(true);
             PlayerPrefs.Save();
             SceneManager.LoadScene("SampleScene");
         }

--- a/Assets/_Project/Scripts/World/ChunkManager.cs
+++ b/Assets/_Project/Scripts/World/ChunkManager.cs
@@ -92,6 +92,14 @@ namespace ReverseRabbitRunner.World
         {
             urpLit = Shader.Find("Universal Render Pipeline/Lit");
 
+            // Seed the world generator before any spawn call below. Daily mode
+            // gets the deterministic seed-of-the-day; otherwise we seed from
+            // wall-clock time so each new run still feels fresh.
+            if (Core.DailyRun.IsActive)
+                WorldRng.InitState(Core.DailyRun.TodaySeed);
+            else
+                WorldRng.InitFromTime();
+
             // Destroy editor preview ground (chunks replace it)
             var previewGround = GameObject.Find("[Ground]");
             if (previewGround != null) Destroy(previewGround);
@@ -232,9 +240,9 @@ namespace ReverseRabbitRunner.World
 
             for (int i = 0; i < carrotsPerChunk; i++)
             {
-                int lane = Random.Range(0, maxLanes);
+                int lane = WorldRng.Range(0, maxLanes);
                 float xPos = (lane - maxLanes / 2) * laneWidth;
-                float zPos = chunkStartZ - Random.Range(2f, chunkLength - 2f);
+                float zPos = chunkStartZ - WorldRng.Range(2f, chunkLength - 2f);
 
                 GameObject carrot = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
                 carrot.name = $"Carrot";
@@ -298,8 +306,8 @@ namespace ReverseRabbitRunner.World
             {
                 for (int attempt = 0; attempt < 20; attempt++)
                 {
-                    int lane = Random.Range(0, maxLanes);
-                    float z = chunkStartZ - Random.Range(3f, chunkLength - 3f);
+                    int lane = WorldRng.Range(0, maxLanes);
+                    float z = chunkStartZ - WorldRng.Range(3f, chunkLength - 3f);
 
                     // Avoid overlapping carrots
                     bool carrotConflict = false;
@@ -337,20 +345,20 @@ namespace ReverseRabbitRunner.World
 
                     placed.Add((lane, z));
 
-                    bool isTall = Random.value < tallRatio;
+                    bool isTall = WorldRng.Value < tallRatio;
                     float xPos = (lane - maxLanes / 2) * laneWidth;
                     Vector3 pos = new Vector3(xPos, 0f, z);
 
                     if (isTall)
                     {
-                        if (Random.value < 0.5f)
+                        if (WorldRng.Value < 0.5f)
                             CreateFencePost(parent, pos);
                         else
                             CreateScarecrow(parent, pos);
                     }
                     else
                     {
-                        if (Random.value < 0.5f)
+                        if (WorldRng.Value < 0.5f)
                             CreateFarmCrate(parent, pos);
                         else
                             CreateHayBale(parent, pos);
@@ -451,7 +459,7 @@ namespace ReverseRabbitRunner.World
         private void SpawnPlatformInChunk(Transform parent, float chunkStartZ, int chunkIndex)
         {
             if (chunkIndex < platformStartChunk) return;
-            if (Random.value > platformChance) return;
+            if (WorldRng.Value > platformChance) return;
 
             if (platformBedMat == null)
             {
@@ -461,9 +469,9 @@ namespace ReverseRabbitRunner.World
                 platformCabMat = MakeMat(new Color(0.2f, 0.45f, 0.15f));
             }
 
-            int lane = Random.Range(0, maxLanes);
+            int lane = WorldRng.Range(0, maxLanes);
             float xPos = (lane - maxLanes / 2) * laneWidth;
-            int length = Random.Range(platformMinLength, platformMaxLength + 1);
+            int length = WorldRng.Range(platformMinLength, platformMaxLength + 1);
 
             float zStart = chunkStartZ - chunkLength * 0.3f;
             Vector3 pos = new Vector3(xPos, 0f, zStart);
@@ -644,7 +652,7 @@ namespace ReverseRabbitRunner.World
             bool magnetActive = PowerUps.MagnetEffect.Active != null;
 
             // Roll for which power-up to spawn (mutually exclusive per chunk)
-            float roll = Random.value;
+            float roll = WorldRng.Value;
             float birthCutoff = babiesActive ? 0f : birthCarrotChance;
             float wingCutoff = birthCutoff + (isFlying ? 0f : wingCarrotChance);
             float magnetCutoff = wingCutoff + (magnetActive ? 0f : magnetCarrotChance);
@@ -655,9 +663,9 @@ namespace ReverseRabbitRunner.World
 
             if (!spawnBirth && !spawnWing && !spawnMagnet) return;
 
-            int lane = Random.Range(0, maxLanes);
+            int lane = WorldRng.Range(0, maxLanes);
             float xPos = (lane - maxLanes / 2) * laneWidth;
-            float zPos = chunkStartZ - Random.Range(10f, chunkLength - 10f);
+            float zPos = chunkStartZ - WorldRng.Range(10f, chunkLength - 10f);
 
             if (spawnBirth)
             {

--- a/Assets/_Project/Scripts/World/ObstacleSpawner.cs
+++ b/Assets/_Project/Scripts/World/ObstacleSpawner.cs
@@ -46,12 +46,12 @@ namespace ReverseRabbitRunner.World
         {
             if (obstaclePrefabs == null || obstaclePrefabs.Length == 0) return;
 
-            int lane = Random.Range(0, laneCount);
+            int lane = WorldRng.Range(0, laneCount);
             int centerLane = laneCount / 2;
             float xPos = (lane - centerLane) * laneWidth;
             float zPos = playerTransform.position.z - spawnDistance;
 
-            GameObject prefab = obstaclePrefabs[Random.Range(0, obstaclePrefabs.Length)];
+            GameObject prefab = obstaclePrefabs[WorldRng.Range(0, obstaclePrefabs.Length)];
             Instantiate(prefab, new Vector3(xPos, 0, zPos), Quaternion.identity, transform);
         }
     }

--- a/Assets/_Project/Scripts/World/WorldRng.cs
+++ b/Assets/_Project/Scripts/World/WorldRng.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace ReverseRabbitRunner.World
+{
+    /// <summary>
+    /// Deterministic, scoped pseudo-random source for world generation.
+    ///
+    /// Backed by <see cref="System.Random"/> so it is independent of
+    /// <see cref="UnityEngine.Random"/> — non-world systems (audio,
+    /// cosmetic FX) can keep using the global PRNG without polluting the
+    /// world-layout sequence. This guarantees that two runs initialised
+    /// with the same seed produce the same chunk / obstacle / pickup
+    /// layout (provided WorldRng is the only RNG consulted by the
+    /// generator).
+    ///
+    /// Thread-safe is **not** required — Unity calls all generators on
+    /// the main thread.
+    /// </summary>
+    public static class WorldRng
+    {
+        private static System.Random rng = new System.Random();
+
+        /// <summary>The seed currently driving the generator (informational).</summary>
+        public static int CurrentSeed { get; private set; }
+
+        /// <summary>(Re)initialise with the given seed. Call before any world spawning.</summary>
+        public static void InitState(int seed)
+        {
+            CurrentSeed = seed;
+            rng = new System.Random(seed);
+        }
+
+        /// <summary>Initialise from a non-deterministic source.</summary>
+        public static void InitFromTime()
+        {
+            int seed = unchecked((int)(DateTime.UtcNow.Ticks & 0x7fffffff));
+            InitState(seed);
+        }
+
+        /// <summary>Returns an int in [minInclusive, maxExclusive).</summary>
+        public static int Range(int minInclusive, int maxExclusive)
+        {
+            if (maxExclusive <= minInclusive) return minInclusive;
+            return rng.Next(minInclusive, maxExclusive);
+        }
+
+        /// <summary>Returns a float in [minInclusive, maxInclusive].</summary>
+        public static float Range(float minInclusive, float maxInclusive)
+        {
+            return minInclusive + (float)rng.NextDouble() * (maxInclusive - minInclusive);
+        }
+
+        /// <summary>Returns a float in [0, 1].</summary>
+        public static float Value => (float)rng.NextDouble();
+    }
+}


### PR DESCRIPTION
Adds a daily-seeded run mode: every player on the same UTC day gets the same chunk layout, with a per-day leaderboard slot.

### Core
- `Assets/_Project/Scripts/World/WorldRng.cs` — scoped `System.Random`-backed PRNG used by world generators. Isolated from `UnityEngine.Random` so cosmetic / audio randomness cannot affect layout.
- `Assets/_Project/Scripts/Core/DailyRun.cs` — FNV-1a hash of the UTC date string (stable across reboots, unlike `DateTime.GetHashCode()`), session toggle, per-day best score in `PlayerPrefs` keyed `DailyBest_yyyy-MM-dd`.

### Generator wiring
- `ChunkManager` and `ObstacleSpawner`: `Random.Range` / `Random.value` → `WorldRng.Range` / `WorldRng.Value`.
- `ChunkManager.Start` calls `WorldRng.InitState(DailyRun.TodaySeed)` when daily mode is active, otherwise `WorldRng.InitFromTime()`.
- `GameManager.GameOver` calls `DailyRun.SubmitScore` when daily mode is active.

### UI
- `MainMenuUI`: new **DAILY RUN** button (with date label), a today's-best line under it, and `OnPlay` now clears daily mode so the normal Play button always starts an infinite run.
- `GameHUD`: top-centre ribbon during a daily run with date, seed (hex), and today's best score.

### Pro touches
- Date hash uses FNV-1a over `yyyyMMdd` rather than `GetHashCode`, which is randomised in modern .NET runtimes — that would defeat the cross-player shared-seed property.
- Seed init runs **before** any chunk spawn in `Start` to avoid a one-frame race.
- WorldRng is the *only* RNG the world generator now consults; `UnityEngine.Random` is left untouched for non-deterministic systems (FX, audio).

### Testing
Static review only. Verified zero remaining `Random.*` references in the migrated files.