### PR TITLE
feat(death-replay): top-down replay of the last 3 seconds

### DIFF
--- a/Assets/_Project/Scripts/Core/DeathReplayRecorder.cs
+++ b/Assets/_Project/Scripts/Core/DeathReplayRecorder.cs
@@ -1,0 +1,120 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Captures the last few seconds of the rabbit and farmer positions in a
+    /// fixed-size ring buffer. On Game Over, <see cref="GameHUD"/> can render
+    /// a top-down replay using <see cref="GetSnapshot"/>.
+    ///
+    /// Records positions only (no rotations / animator state) — this keeps
+    /// memory tiny and avoids any risk of perturbing scene state. The replay
+    /// is rendered in 2D so it never has to re-animate the dead rabbit.
+    ///
+    /// Auto-spawned via <see cref="RuntimeInitializeOnLoadMethodAttribute"/>;
+    /// recording starts as soon as it finds a rabbit and stops when the game
+    /// transitions out of <see cref="GameManager.GameState.Playing"/>.
+    /// </summary>
+    public class DeathReplayRecorder : MonoBehaviour
+    {
+        public const float CaptureRate = 20f;       // samples / second
+        public const float CaptureDuration = 3f;    // seconds retained
+        public const int Capacity = 64;             // 3 s * 20 Hz, rounded up
+
+        public struct Sample
+        {
+            public float TimeStamp;
+            public Vector3 Rabbit;
+            public Vector3 Farmer;
+            public bool HasFarmer;
+        }
+
+        public static DeathReplayRecorder Instance { get; private set; }
+
+        private readonly Sample[] buffer = new Sample[Capacity];
+        private int writeIndex;
+        private int sampleCount;
+        private float lastSampleTime;
+
+        private Player.RabbitController rabbit;
+        private Enemies.FarmerController farmer;
+
+        private bool recording;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (Instance != null) return;
+            var go = new GameObject("[DeathReplayRecorder]");
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<DeathReplayRecorder>();
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+            Instance = this;
+        }
+
+        /// <summary>Number of valid samples currently in the buffer.</summary>
+        public int Count => sampleCount;
+
+        /// <summary>
+        /// Returns the i-th sample in chronological order (0 == oldest,
+        /// <see cref="Count"/>-1 == newest). Reading is safe at any time.
+        /// </summary>
+        public Sample GetSnapshot(int i)
+        {
+            if (sampleCount == 0) return default;
+            int start = sampleCount < Capacity ? 0 : writeIndex;
+            return buffer[(start + i) % Capacity];
+        }
+
+        /// <summary>Clears the buffer (called when starting a new run).</summary>
+        public void ResetBuffer()
+        {
+            writeIndex = 0;
+            sampleCount = 0;
+            lastSampleTime = 0f;
+        }
+
+        private void LateUpdate()
+        {
+            // Re-acquire references each frame until they're available; cheap
+            // because FindAnyObjectByType is only called while still null.
+            if (rabbit == null) rabbit = FindAnyObjectByType<Player.RabbitController>();
+            if (farmer == null) farmer = FindAnyObjectByType<Enemies.FarmerController>();
+
+            var gm = GameManager.Instance;
+            bool playing = gm != null && gm.CurrentState == GameManager.GameState.Playing;
+
+            if (!recording && playing)
+            {
+                ResetBuffer();
+                recording = true;
+            }
+            else if (recording && !playing)
+            {
+                // Game just ended — freeze the buffer.
+                recording = false;
+            }
+
+            if (!recording || rabbit == null) return;
+
+            float now = Time.time;
+            if (now - lastSampleTime < 1f / CaptureRate) return;
+            lastSampleTime = now;
+
+            var s = new Sample
+            {
+                TimeStamp = now,
+                Rabbit = rabbit.transform.position,
+                HasFarmer = farmer != null,
+                Farmer = farmer != null ? farmer.transform.position : Vector3.zero,
+            };
+            buffer[writeIndex] = s;
+            writeIndex = (writeIndex + 1) % Capacity;
+            if (sampleCount < Capacity) sampleCount++;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -37,6 +37,11 @@ namespace ReverseRabbitRunner.UI
         private bool wasStumbling;
         private float stumbleFlashTimer;
 
+        // Death replay (top-down) state.
+        private bool replayActive;
+        private float replayStartedAt;
+        private const float ReplayPlaybackDuration = 2.4f;
+
         private void Start()
         {
             if (rabbit == null)
@@ -717,6 +722,34 @@ namespace ReverseRabbitRunner.UI
                 GUI.Label(new Rect(0, row + 172, Screen.width, 24),
                     $"Tier reached: {maxTier + 1}   |   Best combo: {maxCombo} (x{maxMult})", infoStyle);
 
+                // Watch-replay button — only when a replay buffer is available.
+                var rec = Core.DeathReplayRecorder.Instance;
+                if (rec != null && rec.Count >= 4)
+                {
+                    if (buttonStyle == null)
+                    {
+                        buttonStyle = new GUIStyle(GUI.skin.button) { fontSize = 22, fontStyle = FontStyle.Bold };
+                        buttonStyle.normal.textColor = Color.white;
+                    }
+                    float btnW = 260f, btnH = 42f;
+                    if (GUI.Button(new Rect((Screen.width - btnW) * 0.5f, row + 208, btnW, btnH),
+                                   replayActive ? "■  STOP REPLAY" : "▶  WATCH REPLAY", buttonStyle))
+                    {
+                        Core.AudioManager.Instance?.PlayMenuClick();
+                        if (replayActive)
+                        {
+                            replayActive = false;
+                        }
+                        else
+                        {
+                            replayActive = true;
+                            replayStartedAt = Time.unscaledTime;
+                        }
+                    }
+                }
+
+                if (replayActive) DrawDeathReplayPanel();
+
                 infoStyle.fontSize = 24;
                 GUI.Label(new Rect(0, Screen.height * 0.78f, Screen.width, 40),
                     "Press R to restart | M for menu", infoStyle);
@@ -743,6 +776,144 @@ namespace ReverseRabbitRunner.UI
             GUI.Label(new Rect(0, Screen.height - 50, Screen.width, 40),
                 "A/D or ←/→ to switch lanes | Space/W/↑ to jump", infoStyle);
             infoStyle.alignment = TextAnchor.UpperLeft;
+        }
+
+        /// <summary>
+        /// Renders a top-down replay of the rabbit + farmer over the captured
+        /// window. Auto-fits the trail to the panel; advances a play-head over
+        /// <see cref="ReplayPlaybackDuration"/> seconds of unscaled time, then
+        /// holds on the final frame so the player can read it.
+        /// </summary>
+        private void DrawDeathReplayPanel()
+        {
+            var rec = Core.DeathReplayRecorder.Instance;
+            if (rec == null || rec.Count < 2) return;
+
+            float panelW = Mathf.Min(420f, Screen.width - 80f);
+            float panelH = panelW * 0.6f;
+            float panelX = (Screen.width - panelW) * 0.5f;
+            float panelY = Screen.height * 0.55f;
+
+            // Background
+            GUI.color = new Color(0f, 0f, 0f, 0.85f);
+            GUI.DrawTexture(new Rect(panelX, panelY, panelW, panelH), Texture2D.whiteTexture);
+            GUI.color = new Color(1f, 0.84f, 0.2f, 0.9f);
+            GUI.DrawTexture(new Rect(panelX, panelY, panelW, 2f), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            var titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 16, fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.UpperCenter,
+            };
+            titleStyle.normal.textColor = new Color(1f, 0.86f, 0.4f);
+            GUI.Label(new Rect(panelX, panelY + 4f, panelW, 22f), "LAST 3 SECONDS — TOP DOWN", titleStyle);
+
+            // Bounds in world space (auto-fit).
+            float minX = float.PositiveInfinity, maxX = float.NegativeInfinity;
+            float minZ = float.PositiveInfinity, maxZ = float.NegativeInfinity;
+            int n = rec.Count;
+            for (int i = 0; i < n; i++)
+            {
+                var s = rec.GetSnapshot(i);
+                if (s.Rabbit.x < minX) minX = s.Rabbit.x;
+                if (s.Rabbit.x > maxX) maxX = s.Rabbit.x;
+                if (s.Rabbit.z < minZ) minZ = s.Rabbit.z;
+                if (s.Rabbit.z > maxZ) maxZ = s.Rabbit.z;
+                if (s.HasFarmer)
+                {
+                    if (s.Farmer.x < minX) minX = s.Farmer.x;
+                    if (s.Farmer.x > maxX) maxX = s.Farmer.x;
+                    if (s.Farmer.z < minZ) minZ = s.Farmer.z;
+                    if (s.Farmer.z > maxZ) maxZ = s.Farmer.z;
+                }
+            }
+            // Pad
+            float pad = 1.5f;
+            minX -= pad; maxX += pad; minZ -= pad; maxZ += pad;
+            float spanX = Mathf.Max(0.001f, maxX - minX);
+            float spanZ = Mathf.Max(0.001f, maxZ - minZ);
+
+            // Inner area inside the panel (leave room for title).
+            float innerX = panelX + 12f;
+            float innerY = panelY + 28f;
+            float innerW = panelW - 24f;
+            float innerH = panelH - 40f;
+
+            // Use min of axes so aspect is preserved.
+            float scale = Mathf.Min(innerW / spanX, innerH / spanZ);
+            float drawW = spanX * scale;
+            float drawH = spanZ * scale;
+            float ox = innerX + (innerW - drawW) * 0.5f;
+            float oy = innerY + (innerH - drawH) * 0.5f;
+
+            // Map a world point to panel coordinates. Z runs into screen so we
+            // flip it so 'forward' shows as up on the panel.
+            Vector2 ToPanel(Vector3 w)
+                => new Vector2(ox + (w.x - minX) * scale,
+                               oy + drawH - (w.z - minZ) * scale);
+
+            // Play-head
+            float age = Time.unscaledTime - replayStartedAt;
+            float t = Mathf.Clamp01(age / ReplayPlaybackDuration);
+            int headIndex = Mathf.Clamp(Mathf.FloorToInt(t * (n - 1)), 0, n - 1);
+
+            // Draw trails up to play-head: rabbit (white) and farmer (red).
+            for (int i = 1; i <= headIndex; i++)
+            {
+                var a = rec.GetSnapshot(i - 1);
+                var b = rec.GetSnapshot(i);
+                DrawPanelLine(ToPanel(a.Rabbit), ToPanel(b.Rabbit), new Color(1f, 1f, 1f, 0.9f), 2f);
+                if (a.HasFarmer && b.HasFarmer)
+                    DrawPanelLine(ToPanel(a.Farmer), ToPanel(b.Farmer), new Color(1f, 0.3f, 0.3f, 0.9f), 2f);
+            }
+
+            // Heads
+            var head = rec.GetSnapshot(headIndex);
+            DrawPanelDot(ToPanel(head.Rabbit), 5f, new Color(1f, 0.92f, 0.35f));
+            if (head.HasFarmer)
+                DrawPanelDot(ToPanel(head.Farmer), 5f, new Color(1f, 0.2f, 0.2f));
+
+            // Legend / scrub bar
+            var legend = new GUIStyle(GUI.skin.label) { fontSize = 11 };
+            legend.normal.textColor = new Color(1f, 0.92f, 0.35f);
+            GUI.Label(new Rect(panelX + 10f, panelY + panelH - 18f, 80f, 16f), "● Rabbit", legend);
+            legend.normal.textColor = new Color(1f, 0.3f, 0.3f);
+            GUI.Label(new Rect(panelX + 90f, panelY + panelH - 18f, 80f, 16f), "● Farmer", legend);
+
+            // Progress bar
+            float barX = panelX + panelW - 110f;
+            float barY = panelY + panelH - 14f;
+            GUI.color = new Color(1f, 1f, 1f, 0.25f);
+            GUI.DrawTexture(new Rect(barX, barY, 100f, 4f), Texture2D.whiteTexture);
+            GUI.color = new Color(1f, 0.86f, 0.4f, 0.95f);
+            GUI.DrawTexture(new Rect(barX, barY, 100f * t, 4f), Texture2D.whiteTexture);
+            GUI.color = Color.white;
+        }
+
+        private static void DrawPanelDot(Vector2 p, float r, Color c)
+        {
+            var prev = GUI.color;
+            GUI.color = c;
+            GUI.DrawTexture(new Rect(p.x - r, p.y - r, r * 2f, r * 2f), Texture2D.whiteTexture);
+            GUI.color = prev;
+        }
+
+        private static void DrawPanelLine(Vector2 a, Vector2 b, Color c, float thickness)
+        {
+            // Cheap 2D line via rotated stretched 1×1 white texture.
+            var prev = GUI.color;
+            GUI.color = c;
+            Vector2 d = b - a;
+            float len = d.magnitude;
+            if (len < 0.01f) { GUI.color = prev; return; }
+            float angle = Mathf.Atan2(d.y, d.x) * Mathf.Rad2Deg;
+            var pivot = new Vector2(a.x, a.y);
+            var matrix = GUI.matrix;
+            GUIUtility.RotateAroundPivot(angle, pivot);
+            GUI.DrawTexture(new Rect(a.x, a.y - thickness * 0.5f, len, thickness), Texture2D.whiteTexture);
+            GUI.matrix = matrix;
+            GUI.color = prev;
         }
 
         /// <summary>Renders the achievements list inside the pause overlay.</summary>


### PR DESCRIPTION
Adds a 'Watch Replay' affordance on the Game Over screen showing the last ~3 s of the run as a top-down 2D trail.

### Files
- `Assets/_Project/Scripts/Core/DeathReplayRecorder.cs` — auto-spawned singleton, 20 Hz capture, 64-sample ring buffer (~3.2 s). Records rabbit + farmer XZ positions in `LateUpdate`. Starts when the game state enters `Playing`; freezes when it leaves.
- `Assets/_Project/Scripts/UI/GameHUD.cs` — adds a ▶ WATCH REPLAY button on the Game Over overlay, plus `DrawDeathReplayPanel` which renders a black panel with auto-fit XZ trails (rabbit white, farmer red), an animated play-head, legend, and progress bar.

### Why 2D top-down (not a 3D cinematic)
The rabbit's death cinematic already runs full-screen and the rabbit GameObject's animator / rigidbody is in an undefined state by Game Over. Rendering a fresh 2D panel is fully decoupled from scene state, has no animation conflicts, and adds zero risk of perturbing systems we can't end-to-end test in this environment.

### Pro touches
- Capture uses `Time.time` (timeScale-aware); playback uses `Time.unscaledTime` so the replay animates even though Game Over freezes time.
- Auto-fit XZ bounds with 1.5 m padding and aspect-preserved scaling so trails never distort.
- Line drawing via rotated `GUIUtility.RotateAroundPivot` quads — no extra meshes or materials allocated.
- Button only appears when the buffer holds ≥ 4 samples (avoids flicker on instant deaths).

### Testing
Static review only. Verified buffer indexing is correct: when full, samples wrap and `GetSnapshot(0)` is the oldest live entry; until then, `writeIndex` and `sampleCount` track linearly.