### PR TITLE
feat(tutorial): first-run soft-start with context prompts

### DIFF
--- a/Assets/_Project/Scripts/Core/DifficultyManager.cs
+++ b/Assets/_Project/Scripts/Core/DifficultyManager.cs
@@ -106,6 +106,10 @@ namespace ReverseRabbitRunner.Core
                 if (cachedDistance >= tierThresholds[i]) { t = i; break; }
             }
 
+            // First-run soft start: hold tier 0 while the tutorial is showing
+            // its prompts so the player isn't blindsided by escalation.
+            if (Tutorial.HoldDifficulty) t = 0;
+
             if (t != cachedTier)
             {
                 int prev = cachedTier;

--- a/Assets/_Project/Scripts/Core/Tutorial.cs
+++ b/Assets/_Project/Scripts/Core/Tutorial.cs
@@ -1,0 +1,86 @@
+using System;
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// First-run soft-start tutorial: clamps difficulty to tier 0 for the
+    /// opening seconds and surfaces context-sensitive prompts (lane swap,
+    /// jump, collect a carrot). Once the player completes all three steps —
+    /// or 30 s elapse — the tutorial ends and difficulty resumes its curve.
+    ///
+    /// State machine is shared via static fields so multiple subsystems can
+    /// observe it without coupling. Persistence is intentionally minimal:
+    /// just one PlayerPrefs flag, written when the first run ends so any
+    /// crash or quit *during* the first run still re-shows the tutorial.
+    /// </summary>
+    public static class Tutorial
+    {
+        public enum Step
+        {
+            LaneSwitch,
+            Jump,
+            Carrots,
+            Done,
+        }
+
+        public const float MaxDuration = 30f;
+        private const string FirstRunKey = "HasPlayedBefore";
+
+        public static bool IsFirstRun => PlayerPrefs.GetInt(FirstRunKey, 0) == 0;
+
+        public static bool IsActive { get; private set; }
+        public static Step Current { get; private set; } = Step.Done;
+        public static float StartedAt { get; private set; }
+
+        public static event Action<Step> OnStepChanged;
+
+        /// <summary>Activate at run start when this is a first run.</summary>
+        public static void Begin()
+        {
+            IsActive = true;
+            Current = Step.LaneSwitch;
+            StartedAt = Time.time;
+            OnStepChanged?.Invoke(Current);
+        }
+
+        /// <summary>Force-end the tutorial (e.g. timeout, run end, opt-out).</summary>
+        public static void End()
+        {
+            if (!IsActive && Current == Step.Done) return;
+            IsActive = false;
+            Current = Step.Done;
+            OnStepChanged?.Invoke(Current);
+
+            // Mark the player as no longer a first-timer.
+            if (IsFirstRun)
+            {
+                PlayerPrefs.SetInt(FirstRunKey, 1);
+                PlayerPrefs.Save();
+            }
+        }
+
+        /// <summary>Advance the state machine when an event fires.</summary>
+        public static void Advance(Step completed)
+        {
+            if (!IsActive) return;
+            if ((int)completed != (int)Current) return;
+            Step next = (Step)((int)Current + 1);
+            Current = next;
+            OnStepChanged?.Invoke(Current);
+            if (Current == Step.Done) End();
+        }
+
+        /// <summary>True while difficulty should remain at base tier.</summary>
+        public static bool HoldDifficulty => IsActive;
+
+        /// <summary>The text prompt for the current step (empty when none).</summary>
+        public static string CurrentPrompt => Current switch
+        {
+            Step.LaneSwitch => "← / → or A / D — swipe to switch lanes",
+            Step.Jump       => "Space / W / ↑ — swipe up or tap to jump",
+            Step.Carrots    => "Collect 🥕 carrots — chain them for combos!",
+            _ => string.Empty,
+        };
+    }
+}

--- a/Assets/_Project/Scripts/Core/TutorialController.cs
+++ b/Assets/_Project/Scripts/Core/TutorialController.cs
@@ -1,0 +1,112 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Drives the <see cref="Tutorial"/> state machine: starts it on the
+    /// first run, watches <see cref="Player.RabbitController"/> for lane
+    /// swaps / jumps / carrot pickups, and ends the tutorial after the time
+    /// limit. Auto-spawned via <see cref="RuntimeInitializeOnLoadMethodAttribute"/>
+    /// so the gameplay scene needs no manual wiring.
+    /// </summary>
+    public class TutorialController : MonoBehaviour
+    {
+        public static TutorialController Instance { get; private set; }
+
+        private Player.RabbitController rabbit;
+        private int prevLane = -1;
+        private bool prevJumping;
+        private bool subscribedCarrot;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (Instance != null) return;
+            var go = new GameObject("[TutorialController]");
+            DontDestroyOnLoad(go);
+            Instance = go.AddComponent<TutorialController>();
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+            Instance = this;
+        }
+
+        private void Update()
+        {
+            // Acquire the rabbit lazily; reset cached state when scene reloads
+            // (rabbit destroyed and replaced on R-restart).
+            if (rabbit == null)
+            {
+                rabbit = FindAnyObjectByType<Player.RabbitController>();
+                if (rabbit == null)
+                {
+                    Detach();
+                    return;
+                }
+
+                prevLane = rabbit.CurrentLane;
+                prevJumping = rabbit.IsJumping;
+                if (!subscribedCarrot)
+                {
+                    rabbit.OnCollectCarrot += OnCarrot;
+                    subscribedCarrot = true;
+                }
+
+                // Decide whether to start the tutorial when the player begins
+                // a fresh run. We trigger on Playing state to avoid firing
+                // while the menu / death cinematic owns the scene.
+                var gm = GameManager.Instance;
+                if (gm != null && gm.CurrentState == GameManager.GameState.Playing
+                    && Tutorial.IsFirstRun && !Tutorial.IsActive
+                    && Tutorial.Current == Tutorial.Step.Done)
+                {
+                    Tutorial.Begin();
+                }
+            }
+
+            if (!Tutorial.IsActive) return;
+
+            // Step detection — lane swap, jump rising edge.
+            if (rabbit.CurrentLane != prevLane)
+            {
+                prevLane = rabbit.CurrentLane;
+                Tutorial.Advance(Tutorial.Step.LaneSwitch);
+            }
+            if (rabbit.IsJumping && !prevJumping)
+                Tutorial.Advance(Tutorial.Step.Jump);
+            prevJumping = rabbit.IsJumping;
+
+            // Hard timeout.
+            if (Time.time - Tutorial.StartedAt > Tutorial.MaxDuration)
+                Tutorial.End();
+
+            // End tutorial if the run ended (death cinematic etc.).
+            var gmNow = GameManager.Instance;
+            if (gmNow != null && gmNow.CurrentState != GameManager.GameState.Playing)
+                Tutorial.End();
+        }
+
+        private void OnCarrot(GameObject _)
+        {
+            Tutorial.Advance(Tutorial.Step.Carrots);
+        }
+
+        private void Detach()
+        {
+            if (subscribedCarrot && rabbit != null)
+                rabbit.OnCollectCarrot -= OnCarrot;
+            subscribedCarrot = false;
+            rabbit = null;
+            prevLane = -1;
+            prevJumping = false;
+        }
+
+        private void OnDestroy()
+        {
+            Detach();
+            if (Instance == this) Instance = null;
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -499,6 +499,32 @@ namespace ReverseRabbitRunner.UI
                 infoStyle.normal.textColor = prevColor;
             }
 
+            // Tutorial prompt — top-centre, animated pulse so it stands out.
+            if (Core.Tutorial.IsActive && Core.Tutorial.Current != Core.Tutorial.Step.Done)
+            {
+                string prompt = Core.Tutorial.CurrentPrompt;
+                if (!string.IsNullOrEmpty(prompt))
+                {
+                    var prevAlign2 = infoStyle.alignment;
+                    var prevColor2 = infoStyle.normal.textColor;
+                    var prevSize = infoStyle.fontSize;
+                    float pulse = 0.75f + 0.25f * Mathf.Sin(Time.unscaledTime * 4f);
+                    infoStyle.alignment = TextAnchor.UpperCenter;
+                    infoStyle.fontSize = 22;
+                    infoStyle.normal.textColor = new Color(1f, 1f, 0.7f, pulse);
+
+                    float bgY = 32f, bgH = 36f;
+                    GUI.color = new Color(0f, 0f, 0f, 0.55f);
+                    GUI.DrawTexture(new Rect(Screen.width * 0.15f, bgY, Screen.width * 0.7f, bgH), Texture2D.whiteTexture);
+                    GUI.color = Color.white;
+
+                    GUI.Label(new Rect(0, bgY + 6f, Screen.width, bgH), prompt, infoStyle);
+                    infoStyle.alignment = prevAlign2;
+                    infoStyle.normal.textColor = prevColor2;
+                    infoStyle.fontSize = prevSize;
+                }
+            }
+
             // Chunk/Distance debug stats (bottom-left)
             var chunkMgr = GetChunkMgr();
             if (chunkMgr != null)


### PR DESCRIPTION
First-run players get a 30-second tutorial: difficulty held at base tier and an animated top-centre prompt walks them through lanes, jumping, and carrot combos.

### Files
- `Assets/_Project/Scripts/Core/Tutorial.cs` – static state machine: `IsFirstRun` from PlayerPrefs, step enum, prompt text, `OnStepChanged` event, 30 s hard timeout, `HoldDifficulty` flag.
- `Assets/_Project/Scripts/Core/TutorialController.cs` – auto-spawned MonoBehaviour. Detects lane swaps (`CurrentLane` diff), jump rising-edge (`IsJumping`), and carrot pickups via `OnCollectCarrot`. Triggers `Tutorial.Begin` when the player enters `Playing` on a fresh PlayerPrefs.
- `Assets/_Project/Scripts/Core/DifficultyManager.cs` – clamps tier to 0 when `Tutorial.HoldDifficulty` is true.
- `Assets/_Project/Scripts/UI/GameHUD.cs` – pulsed top-centre prompt with translucent backdrop showing `Tutorial.CurrentPrompt`.

### Pro touches
- The first-run flag is committed to PlayerPrefs in `Tutorial.End`, which is called both on completion *and* on run end (death / quit), so a crash mid-run re-shows the tutorial – the player is never left wondering what happened.
- Detection by polling avoids any new events on the tightly-watched `RabbitController` API surface; only the existing `OnCollectCarrot` event is subscribed.
- `DifficultyManager` clamp is a single line, applied after the threshold scan so the curve resumes the moment the tutorial ends.