### PR TITLE
perf: cache hot-path Find/GetComponent calls

### DIFF
--- a/Assets/_Project/Scripts/Core/DebugOverlay.cs
+++ b/Assets/_Project/Scripts/Core/DebugOverlay.cs
@@ -12,6 +12,12 @@ namespace ReverseRabbitRunner.Core
         private static DebugOverlay instance;
         private bool isVisible;
 
+        // Cached scene refs — re-acquired only when null, so the per-frame
+        // OnGUI paint is allocation-free on the steady state.
+        private Player.RabbitController cachedRabbit;
+        private Enemies.FarmerController cachedFarmer;
+        private World.ChunkManager cachedChunk;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void AutoCreate()
         {
@@ -75,7 +81,8 @@ namespace ReverseRabbitRunner.Core
                 "<color=#00ffff><b>[F11] Game Logic Monitor</b></color>");
 
             // Rabbit state
-            var rabbit = FindAnyObjectByType<Player.RabbitController>();
+            if (cachedRabbit == null) cachedRabbit = FindAnyObjectByType<Player.RabbitController>();
+            var rabbit = cachedRabbit;
             if (rabbit != null)
             {
                 string alive = rabbit.IsAlive ? "<color=#00ff00>✓</color>" : "<color=#ff0000>DEAD</color>";
@@ -92,7 +99,8 @@ namespace ReverseRabbitRunner.Core
             }
 
             // Farmer state
-            var farmer = FindAnyObjectByType<Enemies.FarmerController>();
+            if (cachedFarmer == null) cachedFarmer = FindAnyObjectByType<Enemies.FarmerController>();
+            var farmer = cachedFarmer;
             if (farmer != null && farmer.gameObject.activeSelf)
             {
                 string state;
@@ -154,7 +162,8 @@ namespace ReverseRabbitRunner.Core
                     $"target:{diff.SpeedTarget:F1} farmerX:{diff.FarmerClosenessMultiplier:F2}</color>");
 
             // World stats
-            var chunk = FindAnyObjectByType<World.ChunkManager>();
+            if (cachedChunk == null) cachedChunk = FindAnyObjectByType<World.ChunkManager>();
+            var chunk = cachedChunk;
             if (chunk != null)
             {
                 DrawLine(ref cy, x, w, lineH, style,

--- a/Assets/_Project/Scripts/Core/JuiceVfx.cs
+++ b/Assets/_Project/Scripts/Core/JuiceVfx.cs
@@ -22,6 +22,7 @@ namespace ReverseRabbitRunner.Core
         private ParticleSystem speedLines;
         private ParticleSystem sparkle;
         private ParticleSystem dust;
+        private Camera cachedCam;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void AutoSpawn()
@@ -118,7 +119,8 @@ namespace ReverseRabbitRunner.Core
             // Visible above ~10 u/s, ramps up to a cap of ~22 u/s
             float intensity = Mathf.Clamp01((s - 10f) / 12f);
             // Anchor in front of camera (player runs backwards toward +Z)
-            var cam = Camera.main;
+            if (cachedCam == null) cachedCam = Camera.main;
+            var cam = cachedCam;
             if (cam != null)
             {
                 var t = speedLines.transform;

--- a/Assets/_Project/Scripts/World/ChunkManager.cs
+++ b/Assets/_Project/Scripts/World/ChunkManager.cs
@@ -52,6 +52,7 @@ namespace ReverseRabbitRunner.World
         public int ActiveChunkCount => activeChunks.Count;
 
         private Transform playerTransform;
+        private Player.RabbitController playerRabbit;
         private readonly List<ChunkData> activeChunks = new();
         private float nextSpawnZ;
         private float totalShifted;
@@ -105,7 +106,11 @@ namespace ReverseRabbitRunner.World
             if (previewGround != null) Destroy(previewGround);
 
             var playerObj = GameObject.FindGameObjectWithTag("Player");
-            if (playerObj != null) playerTransform = playerObj.transform;
+            if (playerObj != null)
+            {
+                playerTransform = playerObj.transform;
+                playerRabbit = playerObj.GetComponent<Player.RabbitController>();
+            }
 
             if (playerTransform == null)
             {
@@ -647,8 +652,9 @@ namespace ReverseRabbitRunner.World
             // Don't spawn Birth-Carrot if babies are active; don't spawn Wing-Carrot if flying;
             // don't spawn Magnet-Carrot if one is already active on the rabbit.
             bool babiesActive = PowerUps.BabyRabbit.ActiveBabies.Count > 0;
-            var rabbit = GameObject.FindGameObjectWithTag("Player");
-            bool isFlying = rabbit != null && rabbit.GetComponent<Player.RabbitController>()?.IsFlying == true;
+            // Reuse cached RabbitController set in Start(); avoids a per-chunk
+            // tag scan and GetComponent.
+            bool isFlying = playerRabbit != null && playerRabbit.IsFlying;
             bool magnetActive = PowerUps.MagnetEffect.Active != null;
 
             // Roll for which power-up to spawn (mutually exclusive per chunk)


### PR DESCRIPTION
Tightens three steady-state hot paths:

- `JuiceVfx.UpdateSpeedLines` — caches `Camera.main` (called every frame).
- `DebugOverlay.OnGUI` — caches Rabbit/Farmer/ChunkManager so the F11 overlay paint is allocation-free after first frame.
- `ChunkManager.SpawnPowerUpsInChunk` — reuses the cached `playerTransform` and adds a cached `RabbitController` reference; removes per-chunk `FindGameObjectWithTag` + `GetComponent`.

All caches are lazily re-acquired when null, so scene reloads stay safe. No gameplay changes.