### PR TITLE
feat: live run clock + duration in history/game-over

### DIFF
--- a/Assets/_Project/Scripts/Core/GameManager.cs
+++ b/Assets/_Project/Scripts/Core/GameManager.cs
@@ -18,6 +18,30 @@ namespace ReverseRabbitRunner.Core
 
         public GameState CurrentState => currentState;
 
+        // Run-clock: unscaled-time anchor so pause/timescale tricks can't fake it.
+        private float runStartUnscaledTime;
+        private float runPauseStartUnscaledTime;
+        private float runAccumulatedPauseSeconds;
+        private float lastRunDurationSeconds;
+
+        /// <summary>
+        /// Wall-clock seconds the current (or most recent) run has lasted,
+        /// excluding time spent paused. Resets on a new run start.
+        /// </summary>
+        public float CurrentRunDurationSeconds
+        {
+            get
+            {
+                if (currentState == GameState.Menu) return 0f;
+                if (currentState == GameState.GameOver) return lastRunDurationSeconds;
+                if (currentState == GameState.Paused)
+                {
+                    return runPauseStartUnscaledTime - runStartUnscaledTime - runAccumulatedPauseSeconds;
+                }
+                return Time.unscaledTime - runStartUnscaledTime - runAccumulatedPauseSeconds;
+            }
+        }
+
         public event System.Action<GameState> OnGameStateChanged;
 
         private void Awake()
@@ -54,6 +78,8 @@ namespace ReverseRabbitRunner.Core
 
         public void StartGame()
         {
+            runStartUnscaledTime = Time.unscaledTime;
+            runAccumulatedPauseSeconds = 0f;
             SetState(GameState.Playing);
         }
 
@@ -62,6 +88,7 @@ namespace ReverseRabbitRunner.Core
             if (currentState == GameState.Playing)
             {
                 Time.timeScale = 0f;
+                runPauseStartUnscaledTime = Time.unscaledTime;
                 SetState(GameState.Paused);
             }
         }
@@ -71,12 +98,18 @@ namespace ReverseRabbitRunner.Core
             if (currentState == GameState.Paused)
             {
                 Time.timeScale = 1f;
+                runAccumulatedPauseSeconds += Time.unscaledTime - runPauseStartUnscaledTime;
                 SetState(GameState.Playing);
             }
         }
 
         public void GameOver()
         {
+            // Snapshot the duration BEFORE state flip so CurrentRunDurationSeconds
+            // returns the correct value during the GameOver lifecycle.
+            lastRunDurationSeconds = Mathf.Max(0f,
+                Time.unscaledTime - runStartUnscaledTime - runAccumulatedPauseSeconds);
+
             ScoreManager.Instance?.CommitRunResults();
             // Persist a local history entry for the just-finished run.
             if (ScoreManager.Instance != null)
@@ -88,7 +121,8 @@ namespace ReverseRabbitRunner.Core
                     sm.CarrotsCollected,
                     sm.MaxComboReached,
                     sm.MaxMultiplierReached,
-                    DailyRun.IsActive);
+                    DailyRun.IsActive,
+                    lastRunDurationSeconds);
             }
             // Submit to daily-run leaderboard (per-day best) when applicable.
             if (DailyRun.IsActive && ScoreManager.Instance != null)
@@ -101,6 +135,8 @@ namespace ReverseRabbitRunner.Core
         {
             Time.timeScale = 1f;
             ScoreManager.Instance?.ResetScore();
+            runStartUnscaledTime = Time.unscaledTime;
+            runAccumulatedPauseSeconds = 0f;
             SetState(GameState.Playing);
         }
 

--- a/Assets/_Project/Scripts/Core/ScoreHistory.cs
+++ b/Assets/_Project/Scripts/Core/ScoreHistory.cs
@@ -24,6 +24,7 @@ namespace ReverseRabbitRunner.Core
             public int maxCombo;
             public int maxMultiplier;
             public bool daily;
+            public float durationSeconds;
         }
 
         [Serializable]
@@ -70,7 +71,7 @@ namespace ReverseRabbitRunner.Core
         /// Append a run. Newest first. Trims to <see cref="Capacity"/>.
         /// </summary>
         public static void Submit(int score, float distance, int carrots,
-            int maxCombo, int maxMultiplier, bool daily)
+            int maxCombo, int maxMultiplier, bool daily, float durationSeconds = 0f)
         {
             if (score <= 0 && distance <= 0f && carrots <= 0) return; // ignore empty runs
             var w = Load();
@@ -82,7 +83,8 @@ namespace ReverseRabbitRunner.Core
                 carrots = carrots,
                 maxCombo = maxCombo,
                 maxMultiplier = maxMultiplier,
-                daily = daily
+                daily = daily,
+                durationSeconds = Mathf.Max(0f, durationSeconds),
             };
             w.entries.Insert(0, e);
             if (w.entries.Count > Capacity)
@@ -113,6 +115,16 @@ namespace ReverseRabbitRunner.Core
             PlayerPrefs.DeleteKey(PrefsKey);
             PlayerPrefs.Save();
             OnHistoryChanged?.Invoke();
+        }
+
+        /// <summary>"1:23" / "0:07" mm:ss format (falls back to "—" when unknown).</summary>
+        public static string FormatDuration(float seconds)
+        {
+            if (seconds <= 0f) return "—";
+            int total = Mathf.FloorToInt(seconds);
+            int m = total / 60;
+            int s = total % 60;
+            return $"{m}:{s:00}";
         }
 
         /// <summary>"3m ago", "2h ago", "Yesterday", "12 Apr" — short relative label.</summary>

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -418,6 +418,21 @@ namespace ReverseRabbitRunner.UI
             string scoreText = $"🥕 {(score != null ? score.CurrentScore : 0)}";
             GUI.Label(new Rect(padding, padding, 300, 50), scoreText, scoreStyle);
 
+            // Live run clock, positioned below Speed/Lane stats so it never
+            // overlaps the score label or the combo ribbon.
+            if (game != null && game.CurrentState == Core.GameManager.GameState.Playing)
+            {
+                string clockText = Core.ScoreHistory.FormatDuration(game.CurrentRunDurationSeconds);
+                var prevAlign = infoStyle.alignment;
+                int prevSize = infoStyle.fontSize;
+                infoStyle.alignment = TextAnchor.UpperLeft;
+                infoStyle.fontSize = 16;
+                GUI.Label(new Rect(padding, padding + 95, 160, 22),
+                    $"⏱ {clockText}", infoStyle);
+                infoStyle.alignment = prevAlign;
+                infoStyle.fontSize = prevSize;
+            }
+
             // Combo / streak indicator (under-score, only when active)
             DrawComboHUD(score, padding);
             DrawNearMissPop();
@@ -787,8 +802,9 @@ namespace ReverseRabbitRunner.UI
 
                 // Run highlights
                 infoStyle.fontSize = 18;
+                string durLabel = Core.ScoreHistory.FormatDuration(game.CurrentRunDurationSeconds);
                 GUI.Label(new Rect(0, row + 172, Screen.width, 24),
-                    $"Tier reached: {maxTier + 1}   |   Best combo: {maxCombo} (x{maxMult})", infoStyle);
+                    $"Duration: {durLabel}   |   Tier reached: {maxTier + 1}   |   Best combo: {maxCombo} (x{maxMult})", infoStyle);
 
                 // Watch-replay button — only when a replay buffer is available.
                 var rec = Core.DeathReplayRecorder.Instance;
@@ -1138,7 +1154,7 @@ namespace ReverseRabbitRunner.UI
                     GUI.Label(new Rect(52f, y + 4f, 180f, 26f),
                         $"🥕 {e.score}{(isBest ? "  ★" : string.Empty)}", scoreStyle);
                     GUI.Label(new Rect(52f, y + 28f, content.width - 60f, 22f),
-                        $"{e.distance}m · combo x{e.maxMultiplier} ({e.maxCombo}) · {e.carrots} carrots{(e.daily ? "  ☀ DAILY" : string.Empty)}",
+                        $"{e.distance}m · ⏱ {Core.ScoreHistory.FormatDuration(e.durationSeconds)} · combo x{e.maxMultiplier} ({e.maxCombo}) · {e.carrots} carrots{(e.daily ? "  ☀ DAILY" : string.Empty)}",
                         statStyle);
                     GUI.Label(new Rect(content.width - 180f, y + 4f, 176f, 26f),
                         Core.ScoreHistory.RelativeAge(e.unixSeconds), dateStyle);


### PR DESCRIPTION
Adds a pause-aware wall-clock for every run.

- `GameManager` tracks `runStartUnscaledTime` / `runPauseStartUnscaledTime` / `runAccumulatedPauseSeconds` — Time.timeScale can't fake it. New getter `CurrentRunDurationSeconds` returns live value while Playing, frozen snapshot while GameOver.
- HUD: `⏱ 1:23` compact clock under Speed/Lane while playing.
- Game Over overlay: duration shown on the highlights row.
- `ScoreHistory.Entry` gains `durationSeconds` (legacy entries deserialize as 0 → '—'). `ScoreHistory.FormatDuration` helper.
- Best-Runs panel now prints `⏱ m:ss` in each row.

No gameplay impact.