### PR TITLE
feat: pace / carrots-per-min / near-miss KPIs on Game Over

### DIFF
--- a/Assets/_Project/Scripts/Core/ScoreManager.cs
+++ b/Assets/_Project/Scripts/Core/ScoreManager.cs
@@ -25,6 +25,7 @@ namespace ReverseRabbitRunner.Core
         private int highScore;
         private int runStartHighScore;
         private int carrotsCollected;
+        private int nearMissCount;
         private int maxComboReached;
         private int maxMultiplierReached = 1;
         private int maxTierReached;
@@ -42,6 +43,7 @@ namespace ReverseRabbitRunner.Core
         public int CurrentScore => currentScore;
         public int HighScore => highScore;
         public int CarrotsCollected => carrotsCollected;
+        public int NearMissCount => nearMissCount;
         public int ComboCount => comboCount;
         public int Multiplier => multiplier;
         public int MaxComboReached => maxComboReached;
@@ -158,6 +160,7 @@ namespace ReverseRabbitRunner.Core
         {
             currentScore = 0;
             carrotsCollected = 0;
+            nearMissCount = 0;
             currentRunDistance = 0f;
             maxComboReached = 0;
             maxMultiplierReached = 1;
@@ -196,6 +199,12 @@ namespace ReverseRabbitRunner.Core
         }
 
         public event System.Action OnRunCommitted;
+
+        /// <summary>Tally a near-miss event for the current run. Reset by <see cref="ResetScore"/>.</summary>
+        public void RegisterNearMiss()
+        {
+            nearMissCount++;
+        }
 
         private int ComputeMultiplier(int combo)
         {

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -117,6 +117,7 @@ namespace ReverseRabbitRunner.UI
         {
             Player.CameraFollow.Instance?.Shake(0.08f, 0.15f);
             nearMissFlashTimer = 0.7f;
+            Core.ScoreManager.Instance?.RegisterNearMiss();
             // Reward the dodge — half a carrot's worth, and it counts as a streak hit
             // so dodging masterfully also builds your combo. Anchored at the obstacle
             // so the score-floater pops where the player actually dodged.
@@ -810,6 +811,22 @@ namespace ReverseRabbitRunner.UI
                 GUI.Label(new Rect(0, row + 172, Screen.width, 24),
                     $"Duration: {durLabel}   |   Tier reached: {maxTier + 1}   |   Best combo: {maxCombo} (x{maxMult})", infoStyle);
 
+                // Pace KPIs — derived live from the run snapshot. Guarded against
+                // very short runs (sub-second) so we never display infinity.
+                float dur = Mathf.Max(0.001f, game.CurrentRunDurationSeconds);
+                int carrots = score?.CarrotsCollected ?? 0;
+                int nearMisses = score?.NearMissCount ?? 0;
+                float avgPace = dur >= 0.5f ? runDist / dur : 0f;
+                float carrotsPerMin = dur >= 0.5f ? carrots * 60f / dur : 0f;
+                infoStyle.fontSize = 16;
+                var prevKpiColor = infoStyle.normal.textColor;
+                infoStyle.normal.textColor = new Color(0.78f, 0.85f, 0.95f);
+                GUI.Label(new Rect(0, row + 196, Screen.width, 22),
+                    $"Pace: {avgPace:0.0} m/s   |   Carrots: {carrots} ({carrotsPerMin:0.0}/min)   |   Near-misses: {nearMisses}",
+                    infoStyle);
+                infoStyle.normal.textColor = prevKpiColor;
+                infoStyle.fontSize = 18;
+
                 // Watch-replay button — only when a replay buffer is available.
                 var rec = Core.DeathReplayRecorder.Instance;
                 if (rec != null && rec.Count >= 4)
@@ -820,7 +837,7 @@ namespace ReverseRabbitRunner.UI
                         buttonStyle.normal.textColor = Color.white;
                     }
                     float btnW = 260f, btnH = 42f;
-                    if (GUI.Button(new Rect((Screen.width - btnW) * 0.5f, row + 208, btnW, btnH),
+                    if (GUI.Button(new Rect((Screen.width - btnW) * 0.5f, row + 236, btnW, btnH),
                                    replayActive ? "■  STOP REPLAY" : "▶  WATCH REPLAY", buttonStyle))
                     {
                         Core.AudioManager.Instance?.PlayMenuClick();


### PR DESCRIPTION
Adds a derived KPI line under the highlights row of the Game Over overlay: average pace (m/s), carrots collected + carrots/min, and near-miss tally.

`ScoreManager` gains a `NearMissCount` field + `RegisterNearMiss()` API, hooked from `GameHUD.OnRabbitNearMiss`. Reset alongside the other per-run counters. KPI row uses a soft blue tint to read as secondary stats; replay button shifts down to keep spacing.