### PR TITLE
feat: Skip Track button in Settings

### DIFF
--- a/Assets/_Project/Scripts/Core/MusicPlayer.cs
+++ b/Assets/_Project/Scripts/Core/MusicPlayer.cs
@@ -168,6 +168,9 @@ namespace ReverseRabbitRunner.Core
             Debug.Log($"[MusicPlayer] Now playing: {clip.name} ({clip.length:F1}s)");
         }
 
+        /// <summary>True once the Resources/Music playlist has at least one clip loaded.</summary>
+        public bool HasPlaylist => playlist != null && playlist.Count > 0;
+
         /// <summary>
         /// Skip to next track with crossfade.
         /// </summary>

--- a/Assets/_Project/Scripts/UI/GameHUD.cs
+++ b/Assets/_Project/Scripts/UI/GameHUD.cs
@@ -681,6 +681,20 @@ namespace ReverseRabbitRunner.UI
                     if (Core.MusicPlayer.Instance != null)
                         Core.MusicPlayer.Instance.Volume = musicVol;
 
+                    // Skip-track button — only when the music player exists and
+                    // has a playlist loaded. Disabled-look (greyed) otherwise.
+                    var music = Core.MusicPlayer.Instance;
+                    bool canSkip = music != null && music.HasPlaylist;
+                    var prevEnabled = GUI.enabled;
+                    GUI.enabled = canSkip;
+                    var skipRect = new Rect(cx + 160, Screen.height * 0.61f, 100, 26);
+                    if (GUI.Button(skipRect, "⏭  Skip"))
+                    {
+                        Core.AudioManager.Instance?.PlayMenuClick();
+                        music?.SkipTrack();
+                    }
+                    GUI.enabled = prevEnabled;
+
                     // Accessibility --------------------------------------------
                     infoStyle.fontSize = 22;
                     GUI.Label(new Rect(0, Screen.height * 0.67f, Screen.width, 26), "Accessibility", infoStyle);


### PR DESCRIPTION
Small Skip button next to the Music Volume slider in the pause Settings panel. Crossfades to the next shuffled track via the existing `SkipTrack` API. Greyed out when the playlist is empty (no clips in `Resources/Music`).