### PR TITLE
feat: personal-best beacon banner

### DIFF
--- a/Assets/_Project/Scripts/Core/PersonalBestBeacon.cs
+++ b/Assets/_Project/Scripts/Core/PersonalBestBeacon.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+
+namespace ReverseRabbitRunner.Core
+{
+    /// <summary>
+    /// Watches the live run distance against the player's saved best-distance
+    /// record and triggers a one-shot celebration banner the instant the
+    /// current run surpasses it. Fires only while the game is in the Playing
+    /// state, only once per run, and only when there is an existing record
+    /// to beat (i.e. <see cref="ScoreManager.BestDistance"/> &gt; 0).
+    ///
+    /// Pairs with the existing <see cref="UI.MilestoneBanner"/> by calling
+    /// its public <c>Trigger</c> hook — no new UI plumbing required.
+    /// </summary>
+    public class PersonalBestBeacon : MonoBehaviour
+    {
+        public static PersonalBestBeacon Instance { get; private set; }
+
+        private float baselineBest;
+        private bool firedThisRun;
+        private bool armed;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void AutoSpawn()
+        {
+            if (Instance != null) return;
+            var go = new GameObject("[PersonalBestBeacon]");
+            DontDestroyOnLoad(go);
+            go.AddComponent<PersonalBestBeacon>();
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+            Instance = this;
+        }
+
+        private void OnEnable()
+        {
+            var gm = GameManager.Instance;
+            if (gm != null) gm.OnGameStateChanged += OnGameStateChanged;
+        }
+
+        private void OnDisable()
+        {
+            var gm = GameManager.Instance;
+            if (gm != null) gm.OnGameStateChanged -= OnGameStateChanged;
+        }
+
+        private void Update()
+        {
+            // Late-bind to GameManager: it's created at scene load and our
+            // OnEnable fires before that in some scenes.
+            if (!armed)
+            {
+                var gm = GameManager.Instance;
+                if (gm != null)
+                {
+                    gm.OnGameStateChanged += OnGameStateChanged;
+                    armed = true;
+                    OnGameStateChanged(gm.CurrentState);
+                }
+            }
+
+            if (firedThisRun) return;
+            var gmNow = GameManager.Instance;
+            if (gmNow == null || gmNow.CurrentState != GameManager.GameState.Playing) return;
+            var sm = ScoreManager.Instance;
+            if (sm == null) return;
+
+            // Only meaningful when there is a previous record to beat.
+            if (baselineBest <= 0.5f) return;
+
+            if (sm.CurrentRunDistance > baselineBest)
+            {
+                firedThisRun = true;
+                int rounded = Mathf.RoundToInt(baselineBest);
+                UI.MilestoneBanner.Instance?.Trigger(
+                    "PERSONAL BEST!",
+                    $"Surpassed {rounded} m — keep going!",
+                    chimeIndex: 2);
+            }
+        }
+
+        private void OnGameStateChanged(GameManager.GameState state)
+        {
+            if (state == GameManager.GameState.Playing)
+            {
+                // Capture the bar to beat at the moment this run starts.
+                // Subsequent re-entries to Playing (e.g. resume from pause)
+                // must NOT reset, so we key on whether we've fired yet.
+                var sm = ScoreManager.Instance;
+                if (sm != null && sm.CurrentRunDistance < 1f)
+                {
+                    baselineBest = sm.BestDistance;
+                    firedThisRun = false;
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/MilestoneBanner.cs
+++ b/Assets/_Project/Scripts/UI/MilestoneBanner.cs
@@ -16,6 +16,7 @@ namespace ReverseRabbitRunner.UI
         private const float FadeOut = 0.5f;
 
         private string currentLabel;
+        private string currentSub = "MILESTONE REACHED";
         private float startedAt;
         private bool active;
 
@@ -50,13 +51,22 @@ namespace ReverseRabbitRunner.UI
 
         private void HandleMilestone(int meters, string label)
         {
+            Trigger(label, "MILESTONE REACHED", meters >= 5000 ? 2 : 1);
+        }
+
+        /// <summary>
+        /// Trigger the celebratory banner with a custom title + sub-line. Intended for
+        /// other one-shot reward events (e.g. surpassing personal best distance).
+        /// chimeIndex is forwarded to <see cref="Core.AudioManager.PlayCollectSpecial"/>.
+        /// </summary>
+        public void Trigger(string label, string sub, int chimeIndex = 1)
+        {
             currentLabel = label;
+            currentSub = string.IsNullOrEmpty(sub) ? "" : sub;
             startedAt = Time.unscaledTime;
             active = true;
 
-            // Reuse the "collect special" chime; cheaper than adding a new clip
-            // and it already fits the arcade feel.
-            Core.AudioManager.Instance?.PlayCollectSpecial(meters >= 5000 ? 2 : 1);
+            Core.AudioManager.Instance?.PlayCollectSpecial(chimeIndex);
         }
 
         private void EnsureStyles()
@@ -118,7 +128,7 @@ namespace ReverseRabbitRunner.UI
             GUI.Label(new Rect(cx - w * 0.5f, cy - h * 0.5f, w, h * 0.7f), currentLabel, mainStyle);
 
             subStyle.normal.textColor = new Color(1f, 1f, 1f, 0.85f * a);
-            GUI.Label(new Rect(cx - w * 0.5f, cy + h * 0.15f, w, 30f), "MILESTONE REACHED", subStyle);
+            GUI.Label(new Rect(cx - w * 0.5f, cy + h * 0.15f, w, 30f), currentSub, subStyle);
 
             GUI.matrix = matrix;
             GUI.color = Color.white;


### PR DESCRIPTION
Celebrates the moment your live distance passes your saved best — fires once per run via a new `PersonalBestBeacon` that calls the existing `MilestoneBanner` through a small public `Trigger(label, sub, chime)` hook.

Guards: only when `BestDistance > 0` (skips first-time saves) and only while `GameState.Playing`. Pause/resume safe — uses the run-start distance gate (`< 1m`) to detect a fresh run rather than every Playing transition.